### PR TITLE
Removing standard profile. It seems that it's not needed anymore. Eit…

### DIFF
--- a/configuration/drupal/core.extension.yml
+++ b/configuration/drupal/core.extension.yml
@@ -75,7 +75,6 @@ module:
   views_ui: 0
   menu_link_content: 1
   views: 10
-  standard: 1000
 theme:
   stable: 0
   classy: 0


### PR DESCRIPTION
…her way, it has dependencies to Contextual Links and Quick Edit which both are disabled.

DDSDK-282