### PR TITLE
Patch search_api_solr with to fix bug in date handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,9 @@
             },
             "drupal/facets": {
                 "2833340: Sort facets by term weight": "https://www.drupal.org/files/issues/sort_facets_by_weight-2833340.patch"
+            },
+            "drupal/search_api_solr": {
+                "2747849: search_api_solr handles UTC dates as if they where in the local TZ": "https://www.drupal.org/files/issues/timezone-handling-2747849-6.patch"
             }
         }
     }


### PR DESCRIPTION
Date-fields are all in UTC, but when indexing them search_api_solr
parsed a formatted version of the date without a timezone specified
causing php to assume the timestamp was in UTC+1 and indexing a wrongly
corrected timestamp (now effectivly UTC-1)

DDSDK-361