### PR TITLE
Add view mode for paragraphs to index section pages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3621,20 +3621,20 @@
         },
         {
             "name": "drupal/search_api",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/search_api",
-                "reference": "8.x-1.5"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "e03324c0e2fede8d283db83ec4a5f2ed4b818934"
+                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "c590bfb9752f39087e66ea9ff6c98ad103508f0b"
             },
             "require": {
-                "drupal/core": "^8.3"
+                "drupal/core": "^8.4"
             },
             "require-dev": {
                 "drupal/search_api_autocomplete": "@dev",
@@ -3646,11 +3646,16 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1507989244",
+                    "version": "8.x-1.6",
+                    "datestamp": "1514109785",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
                     }
                 }
             },
@@ -3730,17 +3735,17 @@
         },
         {
             "name": "drupal/search_api_solr",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/search_api_solr",
-                "reference": "8.x-1.1"
+                "reference": "8.x-1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api_solr-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "ff124407b883c9e56030e8c10dcd8827c922cceb"
+                "url": "https://ftp.drupal.org/files/projects/search_api_solr-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "cd77fc851d36ecfb04a0c29967c93e5c47e2d2c6"
             },
             "require": {
                 "drupal/core": "~8.0",
@@ -3751,7 +3756,8 @@
                 "drupal/facets": "1.x-dev",
                 "drupal/geofield": "1.x-dev",
                 "drupal/search_api_autocomplete": "1.x-dev",
-                "drupal/search_api_location": "1.x-dev"
+                "drupal/search_api_location": "1.x-dev",
+                "phayes/geophp": "dev-master"
             },
             "suggest": {
                 "drupal/facets": "Provides facetted search.",
@@ -3763,8 +3769,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1505488645",
+                    "version": "8.x-1.2",
+                    "datestamp": "1509546906",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/configuration/drupal/core.entity_view_display.block_content.content_list.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.block_content.content_list.search_index.yml
@@ -1,0 +1,33 @@
+uuid: 3abd5794-c43e-4dd3-a8f0-b118bea60c2d
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_list
+    - core.entity_view_mode.block_content.search_index
+    - field.field.block_content.content_list.field_content_list
+    - field.field.block_content.content_list.field_content_list_title
+id: block_content.content_list.search_index
+targetEntityType: block_content
+bundle: content_list
+mode: search_index
+content:
+  field_content_list:
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_content_list_title:
+    type: string
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/configuration/drupal/core.entity_view_display.media.image.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.media.image.search_index.yml
@@ -1,0 +1,30 @@
+uuid: bd3649c2-3a86-4d00-9007-c67329ecb69b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.search_index
+    - field.field.media.image.field_byline
+    - field.field.media.image.field_caption
+    - field.field.media.image.field_image
+    - media_entity.bundle.image
+id: media.image.search_index
+targetEntityType: media
+bundle: image
+mode: search_index
+content:
+  field_caption:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  created: true
+  field_byline: true
+  field_image: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.media.video.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.media.video.search_index.yml
@@ -1,0 +1,28 @@
+uuid: 70e52682-5dc7-4e55-b523-f6fb8a3440ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.search_index
+    - field.field.media.video.field_caption
+    - field.field.media.video.field_media_video_embed_field
+    - media_entity.bundle.video
+id: media.video.search_index
+targetEntityType: media
+bundle: video
+mode: search_index
+content:
+  field_caption:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  created: true
+  field_media_video_embed_field: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.node.activity.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.node.activity.search_index.yml
@@ -1,0 +1,52 @@
+uuid: 4c63ec22-a183-4220-81a4-b6d1cd2bbe3b
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.activity.field_activity_id
+    - field.field.node.activity.field_content_topic
+    - field.field.node.activity.field_main_media
+    - field.field.node.activity.field_subtitle
+    - node.type.activity
+  module:
+    - user
+id: node.activity.search_index
+targetEntityType: node
+bundle: activity
+mode: search_index
+content:
+  field_activity_id:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: number_unformatted
+    region: content
+  field_content_topic:
+    weight: 3
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_main_media:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_subtitle:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.activity.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.activity.search_index_teaser.yml
@@ -1,0 +1,40 @@
+uuid: 30599ba4-ae55-488c-bdb5-f26269cd70e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index_teaser
+    - field.field.node.activity.field_activity_id
+    - field.field.node.activity.field_content_topic
+    - field.field.node.activity.field_main_media
+    - field.field.node.activity.field_subtitle
+    - node.type.activity
+  module:
+    - user
+id: node.activity.search_index_teaser
+targetEntityType: node
+bundle: activity
+mode: search_index_teaser
+content:
+  field_activity_id:
+    weight: 0
+    label: hidden
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+    region: content
+  field_content_topic:
+    weight: 1
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  field_main_media: true
+  field_subtitle: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.article.default.yml
+++ b/configuration/drupal/core.entity_view_display.node.article.default.yml
@@ -19,7 +19,6 @@ dependencies:
   module:
     - entity_reference_revisions
     - metatag
-    - search_api_exclude_entity
     - user
 id: node.article.default
 targetEntityType: node
@@ -43,16 +42,6 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view
-    region: content
-  field_exclude_from_search:
-    weight: 8
-    label: above
-    settings:
-      format: yes-no
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: search_api_exclude_entity_formatter
     region: content
   field_main_media:
     type: entity_reference_entity_view
@@ -97,12 +86,13 @@ content:
     region: content
   links:
     weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   field_article_type: true
   field_content_category: true
   field_content_tag: true
   field_content_target_group: true
+  field_exclude_from_search: true
   langcode: true

--- a/configuration/drupal/core.entity_view_display.node.article.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.node.article.search_index.yml
@@ -1,0 +1,111 @@
+uuid: 520ea905-5229-4320-bbce-0264029816bd
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.article.field_article_type
+    - field.field.node.article.field_content_author
+    - field.field.node.article.field_content_category
+    - field.field.node.article.field_content_tag
+    - field.field.node.article.field_content_target_group
+    - field.field.node.article.field_content_topic
+    - field.field.node.article.field_exclude_from_search
+    - field.field.node.article.field_main_media
+    - field.field.node.article.field_metatags
+    - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_sidedeck
+    - field.field.node.article.field_subtitle
+    - node.type.article
+  module:
+    - entity_reference_revisions
+    - metatag
+    - user
+id: node.article.search_index
+targetEntityType: node
+bundle: article
+mode: search_index
+content:
+  field_content_author:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: plaintext
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_content_category:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+  field_content_tag:
+    type: entity_reference_label
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+  field_content_target_group:
+    type: entity_reference_label
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+  field_content_topic:
+    weight: 0
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_main_media:
+    type: entity_reference_entity_view
+    weight: 6
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_metatags:
+    weight: 9
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
+    region: content
+  field_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 8
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_subtitle:
+    weight: 7
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  links:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_article_type: true
+  field_exclude_from_search: true
+  field_sidedeck: true
+  langcode: true

--- a/configuration/drupal/core.entity_view_display.node.article.search_index_extended_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.article.search_index_extended_teaser.yml
@@ -1,0 +1,62 @@
+uuid: 5f8b05f5-976c-46c4-9010-3b719c7e11b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index_extended_teaser
+    - field.field.node.article.field_article_type
+    - field.field.node.article.field_content_author
+    - field.field.node.article.field_content_category
+    - field.field.node.article.field_content_tag
+    - field.field.node.article.field_content_target_group
+    - field.field.node.article.field_content_topic
+    - field.field.node.article.field_exclude_from_search
+    - field.field.node.article.field_main_media
+    - field.field.node.article.field_metatags
+    - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_sidedeck
+    - field.field.node.article.field_subtitle
+    - node.type.article
+  module:
+    - user
+id: node.article.search_index_extended_teaser
+targetEntityType: node
+bundle: article
+mode: search_index_extended_teaser
+content:
+  field_content_topic:
+    weight: 2
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_main_media:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_subtitle:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  field_article_type: true
+  field_content_author: true
+  field_content_category: true
+  field_content_tag: true
+  field_content_target_group: true
+  field_exclude_from_search: true
+  field_metatags: true
+  field_paragraphs: true
+  field_sidedeck: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.article.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.article.search_index_teaser.yml
@@ -1,0 +1,56 @@
+uuid: 8481a1f1-e8f1-4ebd-8e0e-a89284653d6b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index_teaser
+    - field.field.node.article.field_article_type
+    - field.field.node.article.field_content_author
+    - field.field.node.article.field_content_category
+    - field.field.node.article.field_content_tag
+    - field.field.node.article.field_content_target_group
+    - field.field.node.article.field_content_topic
+    - field.field.node.article.field_exclude_from_search
+    - field.field.node.article.field_main_media
+    - field.field.node.article.field_metatags
+    - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_sidedeck
+    - field.field.node.article.field_subtitle
+    - node.type.article
+  module:
+    - user
+id: node.article.search_index_teaser
+targetEntityType: node
+bundle: article
+mode: search_index_teaser
+content:
+  field_content_topic:
+    type: entity_reference_label
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+  field_main_media:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_article_type: true
+  field_content_author: true
+  field_content_category: true
+  field_content_tag: true
+  field_content_target_group: true
+  field_exclude_from_search: true
+  field_metatags: true
+  field_paragraphs: true
+  field_sidedeck: true
+  field_subtitle: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.badge.default.yml
+++ b/configuration/drupal/core.entity_view_display.node.badge.default.yml
@@ -21,7 +21,6 @@ dependencies:
     - entity_reference_revisions
     - metatag
     - options
-    - search_api_exclude_entity
     - user
 id: node.badge.default
 targetEntityType: node
@@ -58,16 +57,6 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    region: content
-  field_exclude_from_search:
-    weight: 8
-    label: above
-    settings:
-      format: yes-no
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: search_api_exclude_entity_formatter
     region: content
   field_main_media:
     type: entity_reference_entity_view
@@ -108,5 +97,6 @@ hidden:
   field_badge_progression: true
   field_content_tag: true
   field_content_topic: true
+  field_exclude_from_search: true
   langcode: true
   links: true

--- a/configuration/drupal/core.entity_view_display.node.badge.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.node.badge.search_index.yml
@@ -1,0 +1,113 @@
+uuid: b73f4434-4e86-4e73-a021-6feafb360fdf
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.badge.field_badge_cover_image
+    - field.field.node.badge.field_badge_level
+    - field.field.node.badge.field_badge_progression
+    - field.field.node.badge.field_badge_summary
+    - field.field.node.badge.field_badge_target_group
+    - field.field.node.badge.field_badge_type
+    - field.field.node.badge.field_content_tag
+    - field.field.node.badge.field_content_topic
+    - field.field.node.badge.field_exclude_from_search
+    - field.field.node.badge.field_main_media
+    - field.field.node.badge.field_metatags
+    - field.field.node.badge.field_paragraphs
+    - field.field.node.badge.field_sidedeck
+    - node.type.badge
+  module:
+    - entity_reference_revisions
+    - metatag
+    - options
+    - search_api_exclude_entity
+    - user
+id: node.badge.search_index
+targetEntityType: node
+bundle: badge
+mode: search_index
+content:
+  field_badge_cover_image:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: section_main_media_25_6
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_badge_summary:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_badge_target_group:
+    type: entity_reference_label
+    weight: 3
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_badge_type:
+    type: list_default
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_exclude_from_search:
+    weight: 8
+    label: above
+    settings:
+      format: yes-no
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: search_api_exclude_entity_formatter
+    region: content
+  field_main_media:
+    type: entity_reference_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: original
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_metatags:
+    weight: 7
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
+    region: content
+  field_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_sidedeck:
+    weight: 6
+    label: hidden
+    settings:
+      view_mode: teaser_list
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+hidden:
+  field_badge_level: true
+  field_badge_progression: true
+  field_content_tag: true
+  field_content_topic: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.badge.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.badge.search_index_teaser.yml
@@ -1,0 +1,58 @@
+uuid: c0d06b39-02d6-43c5-80bd-c8fdc15f2196
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index_teaser
+    - field.field.node.badge.field_badge_cover_image
+    - field.field.node.badge.field_badge_level
+    - field.field.node.badge.field_badge_progression
+    - field.field.node.badge.field_badge_summary
+    - field.field.node.badge.field_badge_target_group
+    - field.field.node.badge.field_badge_type
+    - field.field.node.badge.field_content_tag
+    - field.field.node.badge.field_content_topic
+    - field.field.node.badge.field_exclude_from_search
+    - field.field.node.badge.field_main_media
+    - field.field.node.badge.field_metatags
+    - field.field.node.badge.field_paragraphs
+    - field.field.node.badge.field_sidedeck
+    - node.type.badge
+  module:
+    - options
+    - user
+id: node.badge.search_index_teaser
+targetEntityType: node
+bundle: badge
+mode: search_index_teaser
+content:
+  field_badge_type:
+    type: list_default
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_main_media:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_badge_cover_image: true
+  field_badge_level: true
+  field_badge_progression: true
+  field_badge_summary: true
+  field_badge_target_group: true
+  field_content_tag: true
+  field_content_topic: true
+  field_exclude_from_search: true
+  field_metatags: true
+  field_paragraphs: true
+  field_sidedeck: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.download.default.yml
+++ b/configuration/drupal/core.entity_view_display.node.download.default.yml
@@ -12,23 +12,12 @@ dependencies:
     - node.type.download
   module:
     - file
-    - search_api_exclude_entity
     - user
 id: node.download.default
 targetEntityType: node
 bundle: download
 mode: default
 content:
-  field_exclude_from_search:
-    weight: 1
-    label: above
-    settings:
-      format: yes-no
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: search_api_exclude_entity_formatter
-    region: content
   field_file:
     weight: 0
     label: above
@@ -41,5 +30,6 @@ hidden:
   field_content_tag: true
   field_content_target_group: true
   field_content_topic: true
+  field_exclude_from_search: true
   langcode: true
   links: true

--- a/configuration/drupal/core.entity_view_display.node.download.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.node.download.search_index.yml
@@ -1,0 +1,36 @@
+uuid: a7874072-3877-4867-80f9-2173aaaa0848
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.download.field_content_category
+    - field.field.node.download.field_content_tag
+    - field.field.node.download.field_content_target_group
+    - field.field.node.download.field_content_topic
+    - field.field.node.download.field_exclude_from_search
+    - field.field.node.download.field_file
+    - node.type.download
+  module:
+    - user
+id: node.download.search_index
+targetEntityType: node
+bundle: download
+mode: search_index
+content:
+  field_content_category:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+hidden:
+  field_content_tag: true
+  field_content_target_group: true
+  field_content_topic: true
+  field_exclude_from_search: true
+  field_file: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.download.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.download.search_index_teaser.yml
@@ -1,0 +1,29 @@
+uuid: a68d249a-0e93-4f2d-920f-cdfa905f5404
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index_teaser
+    - field.field.node.download.field_content_category
+    - field.field.node.download.field_content_tag
+    - field.field.node.download.field_content_target_group
+    - field.field.node.download.field_content_topic
+    - field.field.node.download.field_exclude_from_search
+    - field.field.node.download.field_file
+    - node.type.download
+  module:
+    - user
+id: node.download.search_index_teaser
+targetEntityType: node
+bundle: download
+mode: search_index_teaser
+content: {  }
+hidden:
+  field_content_category: true
+  field_content_tag: true
+  field_content_target_group: true
+  field_content_topic: true
+  field_exclude_from_search: true
+  field_file: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.event.default.yml
+++ b/configuration/drupal/core.entity_view_display.node.event.default.yml
@@ -33,7 +33,6 @@ dependencies:
     - entity_reference_revisions
     - field_group
     - metatag
-    - search_api_exclude_entity
     - text
     - user
 third_party_settings:
@@ -227,16 +226,6 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  field_exclude_from_search:
-    weight: 14
-    label: above
-    settings:
-      format: yes-no
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: search_api_exclude_entity_formatter
-    region: content
   field_main_media:
     weight: 0
     label: hidden
@@ -247,7 +236,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_metatags:
-    weight: 13
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -276,5 +265,6 @@ hidden:
   field_content_tag: true
   field_content_topic: true
   field_event_is_all_day: true
+  field_exclude_from_search: true
   langcode: true
   links: true

--- a/configuration/drupal/core.entity_view_display.node.event.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.event.search_index_teaser.yml
@@ -1,9 +1,9 @@
-uuid: dbe02052-a995-44fc-a810-7a1445de742f
+uuid: 4799691e-6880-4fd1-b3e5-7c54bf2d8a4a
 langcode: en
-status: false
+status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.search_index
+    - core.entity_view_mode.node.search_index_teaser
     - field.field.node.event.field_content_category
     - field.field.node.event.field_content_tag
     - field.field.node.event.field_content_target_group
@@ -29,71 +29,20 @@ dependencies:
     - field.field.node.event.field_programs
     - node.type.event
   module:
-    - datetime
     - user
-id: node.event.search_index
+id: node.event.search_index_teaser
 targetEntityType: node
 bundle: event
-mode: search_index
+mode: search_index_teaser
 content:
-  field_event_end:
-    type: datetime_default
-    weight: 6
-    label: hidden
-    settings:
-      format_type: medium
-      timezone_override: ''
-    third_party_settings: {  }
-    region: content
-  field_event_location_name:
-    weight: 3
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_event_price:
-    weight: 4
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_event_start:
-    weight: 2
-    label: hidden
-    settings:
-      timezone_override: ''
-      format_type: medium
-    third_party_settings: {  }
-    type: datetime_default
-    region: content
-  field_event_teaser:
-    weight: 1
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: basic_string
-    region: content
   field_event_type:
-    weight: 5
-    label: hidden
-    settings:
-      link: false
-    third_party_settings: {  }
     type: entity_reference_label
-    region: content
-  field_main_media:
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: wide_teaser
       link: false
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
 hidden:
   field_content_category: true
   field_content_tag: true
@@ -103,11 +52,17 @@ hidden:
   field_event_accommodation: true
   field_event_address: true
   field_event_area: true
+  field_event_end: true
   field_event_host_info: true
   field_event_is_all_day: true
+  field_event_location_name: true
+  field_event_price: true
   field_event_signup_deadline: true
   field_event_signup_instructions: true
+  field_event_start: true
+  field_event_teaser: true
   field_exclude_from_search: true
+  field_main_media: true
   field_metatags: true
   field_paragraphs: true
   field_programs: true

--- a/configuration/drupal/core.entity_view_display.node.section_page.default.yml
+++ b/configuration/drupal/core.entity_view_display.node.section_page.default.yml
@@ -15,23 +15,12 @@ dependencies:
     - node.type.section_page
   module:
     - entity_reference_revisions
-    - search_api_exclude_entity
     - user
 id: node.section_page.default
 targetEntityType: node
 bundle: section_page
 mode: default
 content:
-  field_exclude_from_search:
-    weight: 3
-    label: above
-    settings:
-      format: yes-no
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: search_api_exclude_entity_formatter
-    region: content
   field_main_media:
     type: entity_reference_entity_view
     weight: 0
@@ -62,6 +51,7 @@ hidden:
   field_content_tag: true
   field_content_target_group: true
   field_content_topic: true
+  field_exclude_from_search: true
   field_metatags: true
   langcode: true
   links: true

--- a/configuration/drupal/core.entity_view_display.node.section_page.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.node.section_page.search_index.yml
@@ -1,0 +1,97 @@
+uuid: 997f237f-eb89-4b68-adf2-8acfedfd7f5b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.section_page.field_content_category
+    - field.field.node.section_page.field_content_tag
+    - field.field.node.section_page.field_content_target_group
+    - field.field.node.section_page.field_content_topic
+    - field.field.node.section_page.field_exclude_from_search
+    - field.field.node.section_page.field_main_media
+    - field.field.node.section_page.field_metatags
+    - field.field.node.section_page.field_section
+    - field.field.node.section_page.field_subtitle
+    - node.type.section_page
+  module:
+    - entity_reference_revisions
+    - metatag
+    - user
+id: node.section_page.search_index
+targetEntityType: node
+bundle: section_page
+mode: search_index
+content:
+  field_content_category:
+    type: entity_reference_entity_view
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      view_mode: plaintext
+      link: false
+    third_party_settings: {  }
+  field_content_tag:
+    type: entity_reference_entity_view
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      view_mode: plaintext
+      link: false
+    third_party_settings: {  }
+  field_content_target_group:
+    type: entity_reference_entity_view
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      view_mode: plaintext
+      link: false
+    third_party_settings: {  }
+  field_content_topic:
+    type: entity_reference_entity_view
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      view_mode: plaintext
+      link: false
+    third_party_settings: {  }
+  field_main_media:
+    type: entity_reference_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_metatags:
+    type: metatag_empty_formatter
+    weight: 6
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_section:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_subtitle:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  field_exclude_from_search: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.node.section_page.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.node.section_page.search_index.yml
@@ -25,7 +25,7 @@ mode: search_index
 content:
   field_content_category:
     type: entity_reference_entity_view
-    weight: 3
+    weight: 5
     region: content
     label: hidden
     settings:
@@ -43,7 +43,7 @@ content:
     third_party_settings: {  }
   field_content_target_group:
     type: entity_reference_entity_view
-    weight: 5
+    weight: 3
     region: content
     label: hidden
     settings:
@@ -52,7 +52,7 @@ content:
     third_party_settings: {  }
   field_content_topic:
     type: entity_reference_entity_view
-    weight: 7
+    weight: 2
     region: content
     label: hidden
     settings:
@@ -70,14 +70,14 @@ content:
     region: content
   field_metatags:
     type: metatag_empty_formatter
-    weight: 6
+    weight: 7
     region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
   field_section:
     type: entity_reference_revisions_entity_view
-    weight: 0
+    weight: 6
     label: hidden
     settings:
       view_mode: search_index
@@ -85,7 +85,7 @@ content:
     third_party_settings: {  }
     region: content
   field_subtitle:
-    weight: 2
+    weight: 0
     label: hidden
     settings: {  }
     third_party_settings: {  }

--- a/configuration/drupal/core.entity_view_display.node.section_page.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.section_page.search_index_teaser.yml
@@ -1,0 +1,41 @@
+uuid: df0636a0-5b30-4c1b-a0f3-7546fe0a5964
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index_teaser
+    - field.field.node.section_page.field_content_category
+    - field.field.node.section_page.field_content_tag
+    - field.field.node.section_page.field_content_target_group
+    - field.field.node.section_page.field_content_topic
+    - field.field.node.section_page.field_exclude_from_search
+    - field.field.node.section_page.field_main_media
+    - field.field.node.section_page.field_metatags
+    - field.field.node.section_page.field_section
+    - field.field.node.section_page.field_subtitle
+    - node.type.section_page
+  module:
+    - user
+id: node.section_page.search_index_teaser
+targetEntityType: node
+bundle: section_page
+mode: search_index_teaser
+content:
+  field_subtitle:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  field_content_category: true
+  field_content_tag: true
+  field_content_target_group: true
+  field_content_topic: true
+  field_exclude_from_search: true
+  field_main_media: true
+  field_metatags: true
+  field_section: true
+  langcode: true
+  links: true

--- a/configuration/drupal/core.entity_view_display.paragraph.1col_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.1col_deck.search_index.yml
@@ -1,0 +1,40 @@
+uuid: 623aa82c-1044-40f5-a312-9656a764bdd9
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.1col_deck.field_1col_deck_col1
+    - field.field.paragraph.1col_deck.field_deck_color
+    - field.field.paragraph.1col_deck.field_deck_link
+    - field.field.paragraph.1col_deck.field_deck_title
+    - paragraphs.paragraphs_type.1col_deck
+  module:
+    - entity_reference_revisions
+id: paragraph.1col_deck.search_index
+targetEntityType: paragraph
+bundle: 1col_deck
+mode: search_index
+content:
+  field_1col_deck_col1:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_deck_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  field_deck_color: true
+  field_deck_link: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.2col_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.2col_deck.search_index.yml
@@ -1,0 +1,52 @@
+uuid: d111c42e-04ed-4188-b23a-ab53906bed1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.2col_deck.field_2col_column_size
+    - field.field.paragraph.2col_deck.field_2col_deck_col1
+    - field.field.paragraph.2col_deck.field_2col_deck_col2
+    - field.field.paragraph.2col_deck.field_deck_color
+    - field.field.paragraph.2col_deck.field_deck_link
+    - field.field.paragraph.2col_deck.field_deck_title
+    - paragraphs.paragraphs_type.2col_deck
+  module:
+    - entity_reference_revisions
+id: paragraph.2col_deck.search_index
+targetEntityType: paragraph
+bundle: 2col_deck
+mode: search_index
+content:
+  field_2col_deck_col1:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_2col_deck_col2:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_deck_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  field_2col_column_size: true
+  field_deck_color: true
+  field_deck_link: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.3col_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.3col_deck.search_index.yml
@@ -1,0 +1,60 @@
+uuid: 46a01132-12b4-41b7-bca1-a73480e941c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.3col_deck.field_3col_deck_col1
+    - field.field.paragraph.3col_deck.field_3col_deck_col2
+    - field.field.paragraph.3col_deck.field_3col_deck_col3
+    - field.field.paragraph.3col_deck.field_deck_color
+    - field.field.paragraph.3col_deck.field_deck_link
+    - field.field.paragraph.3col_deck.field_deck_title
+    - paragraphs.paragraphs_type.3col_deck
+  module:
+    - entity_reference_revisions
+id: paragraph.3col_deck.search_index
+targetEntityType: paragraph
+bundle: 3col_deck
+mode: search_index
+content:
+  field_3col_deck_col1:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_3col_deck_col2:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_3col_deck_col3:
+    type: entity_reference_revisions_entity_view
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_deck_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  field_deck_color: true
+  field_deck_link: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.4col_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.4col_deck.search_index.yml
@@ -1,0 +1,70 @@
+uuid: 0ee7c778-125b-4c49-9c72-4ba46b451e04
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.4col_deck.field_4col_deck_col1
+    - field.field.paragraph.4col_deck.field_4col_deck_col2
+    - field.field.paragraph.4col_deck.field_4col_deck_col3
+    - field.field.paragraph.4col_deck.field_4col_deck_col4
+    - field.field.paragraph.4col_deck.field_deck_color
+    - field.field.paragraph.4col_deck.field_deck_link
+    - field.field.paragraph.4col_deck.field_deck_title
+    - paragraphs.paragraphs_type.4col_deck
+  module:
+    - entity_reference_revisions
+id: paragraph.4col_deck.search_index
+targetEntityType: paragraph
+bundle: 4col_deck
+mode: search_index
+content:
+  field_4col_deck_col1:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_4col_deck_col2:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_4col_deck_col3:
+    type: entity_reference_revisions_entity_view
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_4col_deck_col4:
+    type: entity_reference_revisions_entity_view
+    weight: 4
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_deck_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  field_deck_color: true
+  field_deck_link: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.block.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.block.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 2501cfa3-b19f-487e-9204-32668dfde74e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.block.field_block
+    - paragraphs.paragraphs_type.block
+id: paragraph.block.search_index
+targetEntityType: paragraph
+bundle: block
+mode: search_index
+content:
+  field_block:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_activity_reference.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_activity_reference.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 0f998122-d08b-432a-a789-5e890e3aaf1a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.content_activity_reference.field_content_reference
+    - paragraphs.paragraphs_type.content_activity_reference
+id: paragraph.content_activity_reference.search_index
+targetEntityType: paragraph
+bundle: content_activity_reference
+mode: search_index
+content:
+  field_content_reference:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_article_reference.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_article_reference.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 1757d4a0-2607-4bc8-843f-db57a7e792a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.content_article_reference.field_content_reference
+    - paragraphs.paragraphs_type.content_article_reference
+id: paragraph.content_article_reference.search_index
+targetEntityType: paragraph
+bundle: content_article_reference
+mode: search_index
+content:
+  field_content_reference:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_article_reference_ext.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_article_reference_ext.search_index.yml
@@ -1,0 +1,25 @@
+uuid: ae19e4ed-ae51-4dc4-8d77-ae449f5b1aeb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.content_article_reference_ext.field_content_reference
+    - paragraphs.paragraphs_type.content_article_reference_ext
+id: paragraph.content_article_reference_ext.search_index
+targetEntityType: paragraph
+bundle: content_article_reference_ext
+mode: search_index
+content:
+  field_content_reference:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index_extended_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_badge_reference.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_badge_reference.search_index.yml
@@ -1,0 +1,25 @@
+uuid: f6ecce44-e950-465d-8e01-d7487b0ef697
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.content_badge_reference.field_content_reference
+    - paragraphs.paragraphs_type.content_badge_reference
+id: paragraph.content_badge_reference.search_index
+targetEntityType: paragraph
+bundle: content_badge_reference
+mode: search_index
+content:
+  field_content_reference:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_event_reference.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_event_reference.search_index.yml
@@ -1,0 +1,25 @@
+uuid: cd6378d8-7e75-4f46-b8d6-dbff1f3b87dd
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.content_event_reference.field_content_reference
+    - paragraphs.paragraphs_type.content_event_reference
+id: paragraph.content_event_reference.search_index
+targetEntityType: paragraph
+bundle: content_event_reference
+mode: search_index
+content:
+  field_content_reference:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_link.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_link.search_index.yml
@@ -1,0 +1,41 @@
+uuid: 879c75b5-e71f-4a62-8d3c-ba5d56edb66e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.content_link.field_content_link
+    - field.field.paragraph.content_link.field_content_link_lead
+    - field.field.paragraph.content_link.field_show_thumbnail
+    - paragraphs.paragraphs_type.content_link
+  module:
+    - link
+id: paragraph.content_link.search_index
+targetEntityType: paragraph
+bundle: content_link
+mode: search_index
+content:
+  field_content_link:
+    type: link
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  field_content_link_lead:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  field_show_thumbnail: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.download.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.download.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 8cc6605f-7dc0-48e3-9cac-60a3e6d388fc
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.download.field_download
+    - paragraphs.paragraphs_type.download
+id: paragraph.download.search_index
+targetEntityType: paragraph
+bundle: download
+mode: search_index
+content:
+  field_download:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.dynamic_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.dynamic_deck.search_index.yml
@@ -1,0 +1,27 @@
+uuid: 233a68e1-675c-4c91-826c-f190f426d90e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.dynamic_deck.field_paragraphs
+    - paragraphs.paragraphs_type.dynamic_deck
+  module:
+    - entity_reference_revisions
+id: paragraph.dynamic_deck.search_index
+targetEntityType: paragraph
+bundle: dynamic_deck
+mode: search_index
+content:
+  field_paragraphs:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.factbox.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.factbox.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 580d07e1-d04c-4161-972a-7c0c96238360
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.factbox.field_factbox_text
+    - paragraphs.paragraphs_type.factbox
+  module:
+    - text
+id: paragraph.factbox.search_index
+targetEntityType: paragraph
+bundle: factbox
+mode: search_index
+content:
+  field_factbox_text:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.gallery.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.gallery.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 7c57269d-17ef-4795-8350-38db9f7469de
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.gallery.field_gallery_image
+    - paragraphs.paragraphs_type.gallery
+id: paragraph.gallery.search_index
+targetEntityType: paragraph
+bundle: gallery
+mode: search_index
+content:
+  field_gallery_image:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.hero_banner.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.hero_banner.search_index.yml
@@ -1,0 +1,30 @@
+uuid: 4eabcd00-7fde-496f-8635-5271df48f366
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.hero_banner.field_background_image
+    - field.field.paragraph.hero_banner.field_deck_color
+    - field.field.paragraph.hero_banner.field_label
+    - field.field.paragraph.hero_banner.field_links
+    - paragraphs.paragraphs_type.hero_banner
+id: paragraph.hero_banner.search_index
+targetEntityType: paragraph
+bundle: hero_banner
+mode: search_index
+content:
+  field_label:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  field_background_image: true
+  field_deck_color: true
+  field_links: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.image.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.image.search_index.yml
@@ -1,0 +1,25 @@
+uuid: c57f7acd-de70-401b-ac40-1a67665e0bfb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.image.field_media_image
+    - paragraphs.paragraphs_type.image
+id: paragraph.image.search_index
+targetEntityType: paragraph
+bundle: image
+mode: search_index
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.inspiration_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.inspiration_deck.search_index.yml
@@ -1,0 +1,60 @@
+uuid: f253decd-3fc4-474c-a64d-2919ea6b2185
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.inspiration_deck.field_insp_teaser_color
+    - field.field.paragraph.inspiration_deck.field_insp_teaser_heading
+    - field.field.paragraph.inspiration_deck.field_insp_teaser_link
+    - field.field.paragraph.inspiration_deck.field_insp_teaser_text
+    - field.field.paragraph.inspiration_deck.field_inspiration_deck_items
+    - paragraphs.paragraphs_type.inspiration_deck
+  module:
+    - link
+id: paragraph.inspiration_deck.search_index
+targetEntityType: paragraph
+bundle: inspiration_deck
+mode: search_index
+content:
+  field_insp_teaser_heading:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_insp_teaser_link:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    type: link_separate
+    region: content
+  field_insp_teaser_text:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_inspiration_deck_items:
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index_teaser
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden:
+  created: true
+  field_insp_teaser_color: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.key_figures.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.key_figures.search_index.yml
@@ -1,0 +1,41 @@
+uuid: 37179e6a-0020-4704-91bc-bf589ea6352a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.key_figures.field_key_figures_deck_color
+    - field.field.paragraph.key_figures.field_key_figures_desc_1
+    - field.field.paragraph.key_figures.field_key_figures_desc_2
+    - field.field.paragraph.key_figures.field_key_figures_desc_3
+    - field.field.paragraph.key_figures.field_key_figures_figure_1
+    - field.field.paragraph.key_figures.field_key_figures_figure_2
+    - field.field.paragraph.key_figures.field_key_figures_figure_3
+    - field.field.paragraph.key_figures.field_key_figures_label_1
+    - field.field.paragraph.key_figures.field_key_figures_label_2
+    - field.field.paragraph.key_figures.field_key_figures_label_3
+    - field.field.paragraph.key_figures.field_key_figures_link_1
+    - field.field.paragraph.key_figures.field_key_figures_link_2
+    - field.field.paragraph.key_figures.field_key_figures_link_3
+    - paragraphs.paragraphs_type.key_figures
+id: paragraph.key_figures.search_index
+targetEntityType: paragraph
+bundle: key_figures
+mode: search_index
+content: {  }
+hidden:
+  created: true
+  field_key_figures_deck_color: true
+  field_key_figures_desc_1: true
+  field_key_figures_desc_2: true
+  field_key_figures_desc_3: true
+  field_key_figures_figure_1: true
+  field_key_figures_figure_2: true
+  field_key_figures_figure_3: true
+  field_key_figures_label_1: true
+  field_key_figures_label_2: true
+  field_key_figures_label_3: true
+  field_key_figures_link_1: true
+  field_key_figures_link_2: true
+  field_key_figures_link_3: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.latest_content_list.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.latest_content_list.search_index.yml
@@ -1,0 +1,17 @@
+uuid: 4ec6ef9f-ca10-495b-a9bb-0f7be4619b43
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.latest_content_list.field_list_item_count
+    - paragraphs.paragraphs_type.latest_content_list
+id: paragraph.latest_content_list.search_index
+targetEntityType: paragraph
+bundle: latest_content_list
+mode: search_index
+content: {  }
+hidden:
+  created: true
+  field_list_item_count: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.list_deck.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.list_deck.search_index.yml
@@ -1,0 +1,40 @@
+uuid: de3ad570-fb85-4d84-ab38-0226f58f478a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.list_deck.field_deck_color
+    - field.field.paragraph.list_deck.field_deck_link
+    - field.field.paragraph.list_deck.field_deck_title
+    - field.field.paragraph.list_deck.field_list_paragraph
+    - paragraphs.paragraphs_type.list_deck
+  module:
+    - entity_reference_revisions
+id: paragraph.list_deck.search_index
+targetEntityType: paragraph
+bundle: list_deck
+mode: search_index
+content:
+  field_deck_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_list_paragraph:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_deck_color: true
+  field_deck_link: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.program.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.program.search_index.yml
@@ -1,0 +1,36 @@
+uuid: 5c405eee-a969-4b2b-ad89-1e8bbd33f214
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.program.field_program_items
+    - field.field.paragraph.program.field_program_title
+    - paragraphs.paragraphs_type.program
+  module:
+    - entity_reference_revisions
+id: paragraph.program.search_index
+targetEntityType: paragraph
+bundle: program
+mode: search_index
+content:
+  field_program_items:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: search_index
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_program_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.program_item.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.program_item.search_index.yml
@@ -1,0 +1,45 @@
+uuid: 29943f53-4bcb-4d2c-bf5c-4069310233be
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.program_item.field_program_description
+    - field.field.paragraph.program_item.field_program_item_date
+    - field.field.paragraph.program_item.field_program_text
+    - paragraphs.paragraphs_type.program_item
+  module:
+    - datetime_range
+    - text
+id: paragraph.program_item.search_index
+targetEntityType: paragraph
+bundle: program_item
+mode: search_index
+content:
+  field_program_description:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_program_item_date:
+    weight: 3
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: default_time
+      separator: '-'
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
+  field_program_text:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.quotation.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.quotation.search_index.yml
@@ -1,0 +1,23 @@
+uuid: da254b68-2c60-4be1-bffb-f97ca72f9451
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.quotation.field_quotation
+    - paragraphs.paragraphs_type.quotation
+id: paragraph.quotation.search_index
+targetEntityType: paragraph
+bundle: quotation
+mode: search_index
+content:
+  field_quotation:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.shortcuts.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.shortcuts.search_index.yml
@@ -1,0 +1,19 @@
+uuid: 65861a67-e670-429d-91e8-bc45c1668afc
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.shortcuts.field_shortcuts
+    - field.field.paragraph.shortcuts.field_shortcuts_title
+    - paragraphs.paragraphs_type.shortcuts
+id: paragraph.shortcuts.search_index
+targetEntityType: paragraph
+bundle: shortcuts
+mode: search_index
+content: {  }
+hidden:
+  created: true
+  field_shortcuts: true
+  field_shortcuts_title: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.situation_links.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.situation_links.search_index.yml
@@ -1,0 +1,23 @@
+uuid: 50d128d7-5ea5-445b-a1de-bf4dff7c5cf8
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.situation_links.field_icon
+    - field.field.paragraph.situation_links.field_situation_color
+    - field.field.paragraph.situation_links.field_situation_links
+    - field.field.paragraph.situation_links.field_situation_main_link
+    - paragraphs.paragraphs_type.situation_links
+id: paragraph.situation_links.search_index
+targetEntityType: paragraph
+bundle: situation_links
+mode: search_index
+content: {  }
+hidden:
+  created: true
+  field_icon: true
+  field_situation_color: true
+  field_situation_links: true
+  field_situation_main_link: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.text.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.text.search_index.yml
@@ -1,0 +1,25 @@
+uuid: f47e9bf4-fa94-4a95-bf60-ddc689180569
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.text.field_formatted_text
+    - paragraphs.paragraphs_type.text
+  module:
+    - text
+id: paragraph.text.search_index
+targetEntityType: paragraph
+bundle: text
+mode: search_index
+content:
+  field_formatted_text:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden:
+  created: true
+  uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.video.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.video.search_index.yml
@@ -1,0 +1,25 @@
+uuid: 1c3ec61d-0080-4366-a8e0-6afef70891db
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.search_index
+    - field.field.paragraph.video.field_video
+    - field.field.paragraph.video.field_video_caption
+    - paragraphs.paragraphs_type.video
+id: paragraph.video.search_index
+targetEntityType: paragraph
+bundle: video
+mode: search_index
+content:
+  field_video_caption:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  created: true
+  field_video: true
+  uid: true

--- a/configuration/drupal/core.entity_view_mode.block_content.search_index.yml
+++ b/configuration/drupal/core.entity_view_mode.block_content.search_index.yml
@@ -1,0 +1,10 @@
+uuid: 1a564c6a-fe45-4bb6-9606-823da5340669
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.search_index
+label: 'Search index'
+targetEntityType: block_content
+cache: true

--- a/configuration/drupal/core.entity_view_mode.media.search_index.yml
+++ b/configuration/drupal/core.entity_view_mode.media.search_index.yml
@@ -1,0 +1,10 @@
+uuid: d6d9225f-3a0b-4768-a7a6-b42f6c2fdb52
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity
+id: media.search_index
+label: 'Search index'
+targetEntityType: media
+cache: true

--- a/configuration/drupal/core.entity_view_mode.node.search_index_extended_teaser.yml
+++ b/configuration/drupal/core.entity_view_mode.node.search_index_extended_teaser.yml
@@ -1,0 +1,10 @@
+uuid: 0256dfde-4724-4e34-b98f-508e0d4071b4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.search_index_extended_teaser
+label: 'Search index extended teaser'
+targetEntityType: node
+cache: true

--- a/configuration/drupal/core.entity_view_mode.node.search_index_teaser.yml
+++ b/configuration/drupal/core.entity_view_mode.node.search_index_teaser.yml
@@ -1,0 +1,10 @@
+uuid: bc243773-1250-4578-b86a-6b3665761cae
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.search_index_teaser
+label: 'Search index teaser'
+targetEntityType: node
+cache: true

--- a/configuration/drupal/core.entity_view_mode.paragraph.search_index.yml
+++ b/configuration/drupal/core.entity_view_mode.paragraph.search_index.yml
@@ -1,0 +1,10 @@
+uuid: 5d6dcee4-e330-4dbf-8241-202a0c0bc3cd
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.search_index
+label: 'Search index'
+targetEntityType: paragraph
+cache: true

--- a/configuration/drupal/search_api.index.nodes.yml
+++ b/configuration/drupal/search_api.index.nodes.yml
@@ -32,6 +32,7 @@ dependencies:
     - field.storage.node.field_content_target_group
     - field.storage.node.field_content_topic
     - search_api.server.solr
+    - core.entity_view_mode.node.search_index
   module:
     - media_entity
     - paragraphs
@@ -44,6 +45,21 @@ name: Nodes
 description: ''
 read_only: false
 field_settings:
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:node':
+          activity: ''
+          article: ''
+          badge: ''
+          download: ''
+          event: ''
+          section_page: search_index
   nid:
     label: ID
     datasource_id: 'entity:node'
@@ -418,6 +434,39 @@ processor_settings:
   aggregated_field:
     plugin_id: aggregated_field
     settings: {  }
+  entity_status: {  }
+  ignorecase:
+    all_fields: true
+    fields:
+      - rendered_item
+      - type
+      - title
+      - field_subtitle
+      - field_event_location_name
+      - field_event_price
+      - field_event_teaser
+      - main_media_image_field_caption
+      - main_media_image_field_byline
+      - field_factbox_text
+      - field_presentation_name
+      - paragraph_images_field_byline
+      - paragraph_images_field_caption
+      - field_quotation
+      - field_video_caption
+      - event_address_locality
+      - event_address_country_code
+      - event_type_name
+      - postal_code
+      - title_full_text
+      - field_formatted_text
+      - field_article_type
+      - field_content_category_name
+      - field_content_tag_name
+      - field_content_target_group_name
+      - field_content_topic_name
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
   search_api_exclude_entity_processor:
     fields:
       node:

--- a/configuration/drupal/search_api.index.nodes.yml
+++ b/configuration/drupal/search_api.index.nodes.yml
@@ -31,15 +31,17 @@ dependencies:
     - field.storage.node.field_content_tag
     - field.storage.node.field_content_target_group
     - field.storage.node.field_content_topic
+    - field.storage.node.field_sidedeck
+    - field.storage.paragraph.field_download
     - search_api.server.solr
     - core.entity_view_mode.node.search_index
   module:
     - media_entity
     - paragraphs
     - taxonomy
+    - node
     - search_api
     - search_api_exclude_entity
-    - node
 id: nodes
 name: Nodes
 description: ''
@@ -408,6 +410,18 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: sticky
     type: boolean
+  field_download_title:
+    label: 'Sidedeck » Paragraph » Download » Content » Title'
+    datasource_id: 'entity:node'
+    property_path: 'field_sidedeck:entity:field_download:entity:title'
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_sidedeck
+        - field.storage.paragraph.field_download
+      module:
+        - paragraphs
+        - node
 datasource_settings:
   'entity:node':
     plugin_id: 'entity:node'
@@ -464,9 +478,53 @@ processor_settings:
       - field_content_tag_name
       - field_content_target_group_name
       - field_content_topic_name
+      - field_download_title
     weights:
       preprocess_index: -20
       preprocess_query: -20
+  html_filter:
+    all_fields: true
+    fields:
+      - rendered_item
+      - type
+      - title
+      - field_subtitle
+      - field_event_location_name
+      - field_event_price
+      - field_event_teaser
+      - main_media_image_field_caption
+      - main_media_image_field_byline
+      - field_factbox_text
+      - field_presentation_name
+      - paragraph_images_field_byline
+      - paragraph_images_field_caption
+      - field_quotation
+      - field_video_caption
+      - event_address_locality
+      - event_address_country_code
+      - event_type_name
+      - postal_code
+      - title_full_text
+      - field_formatted_text
+      - field_article_type
+      - field_content_category_name
+      - field_content_tag_name
+      - field_content_target_group_name
+      - field_content_topic_name
+      - field_download_title
+    title: true
+    alt: true
+    tags:
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      b: 2
+      em: 1
+      u: 1
+    weights:
+      preprocess_index: -15
+      preprocess_query: -15
   search_api_exclude_entity_processor:
     fields:
       node:
@@ -475,6 +533,7 @@ tracker_settings:
   default:
     plugin_id: default
     settings: {  }
+    indexing_order: fifo
 options:
   index_directly: true
   cron_limit: 50

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -93,16 +93,17 @@ function mungo_preprocess_field(&$variables) {
       $variables['item_col_classes'][] = 'col-xs-6';
     }
   }
-  if ($field_name == 'field_section') {
+  if ($field_name === 'field_section') {
     $prevkey = NULL;
+    $herobannerfound = FALSE;
 
     foreach ($variables['items'] as $key => &$item) {
       /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
-      $paragraph = $item['content']['#paragraph'];
+      $paragraph = isset($item['content']['#paragraph']) ? $item['content']['#paragraph'] : NULL;
 
       // If the a 4col_deck paragraph is right after a herobanner. Set negative
       // margin.
-      if (isset($herobannerfound) && $herobannerfound == TRUE && $paragraph->getType() == '4col_deck') {
+      if (!empty($paragraph) && isset($herobannerfound) && $herobannerfound === TRUE && $paragraph->getType() === '4col_deck') {
         if (!empty($paragraph->field_4col_deck_col1)) {
           $entities = $paragraph->field_4col_deck_col1->referencedEntities();
           $situation_link = reset($entities);
@@ -1051,10 +1052,12 @@ function mungo_theme($existing, $type, $theme, $path) {
 function mungo_inspirational_prerender($elements) {
   if (!empty($elements['field_main_media'])) {
     foreach (Element::children($elements['field_main_media']) as $name) {
-      $elements['field_main_media'][$name]['#view_mode'] = 'extended_teaser';
-      // Make sure this field is going to be rendered again if it is
-      // rendered without this prerender.
-      $elements['field_main_media'][$name]['#cache']['keys'][] = 'mungo_inspirational_prerender';
+      if (!isset($elements['field_main_media'][$name]['#view_mode']) || $elements['field_main_media'][$name]['#view_mode'] === 'teaser') {
+        $elements['field_main_media'][$name]['#view_mode'] = 'extended_teaser';
+        // Make sure this field is going to be rendered again if it is
+        // rendered without this prerender.
+        $elements['field_main_media'][$name]['#cache']['keys'][] = 'mungo_inspirational_prerender';
+      }
     }
   }
   return $elements;


### PR DESCRIPTION
Section pages could not really be indexed as they consists of nested paragraphs. This PR introduces a view mode for indexing and configures searchapi to render section-pages using this viewmode.

Also
![](https://i.imgflip.com/24y651.jpg)

DDSDK-385