### PR TITLE
Make composer fail if patches do not apply

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,7 @@
             "drupal/chosen": {
                 "2705891: Fix invisible required chosen widgets": "https://www.drupal.org/files/issues/2705891-chosen-validation-temp-fix-6.patch"
             }
-        }
+        },
+        "composer-exit-on-patch-failure": true
     }
 }


### PR DESCRIPTION
By default the composer-patches will print out a message if a patch does not apply but the process continues. We want the process to fail entirely to ensure that patch failures hare handled properly.

The other option would be to rely on the COMPOSER_EXIT_ON_PATCH_FAILURE environment variable but we want to ensure that this happens across environments.