### PR TITLE
DDSDK-418 SA-CORE-2018-006

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
         },
         "patches": {
             "drupal/core": {
+                "SA-CORE-2018-006": "https://gist.githubusercontent.com/reload-deploy/a5237b38ec73aeca7de667bf59fbbcbf/raw/768bbd3f46ab87d10e90d291c491373d93e690d5/SA-CORE-2018-006_8-4.patch",
                 "2558207: Add hook to react to image_path_flush() - recommended by the Reloadtina module": "https://www.drupal.org/files/issues/add_hook_image_path_flush-2558207-4.patch",
                 "2408549: Notify about overridden configuration": "https://www.drupal.org/files/issues/2408549-91.patch",
                 "2857132: Account administration pages language negotiation ignores _format blocking REST resources": "https://www.drupal.org/files/issues/preserve-format-while-negoatiating-2857132.patch",


### PR DESCRIPTION
I am choosing to patch core, as we're running an old 8.4.8 version,
and Drupal security is suggesting to update to 8.5.x