### PR TITLE
Add new badge type "other"

### DIFF
--- a/configuration/drupal/field.storage.node.field_badge_type.yml
+++ b/configuration/drupal/field.storage.node.field_badge_type.yml
@@ -20,6 +20,9 @@ settings:
     -
       value: focus
       label: Fokusmærke
+    -
+      value: other
+      label: 'Øvrige mærker'
   allowed_values_function: ''
 module: options
 locked: false

--- a/configuration/drupal/views.view.badges.yml
+++ b/configuration/drupal/views.view.badges.yml
@@ -614,6 +614,7 @@ display:
           value:
             skill: skill
             focus: focus
+            other: other
           group: 1
           exposed: true
           expose:


### PR DESCRIPTION
Added new badge type "other" ("Øvrige mærker") to the badge node type.

The badge type is also added as exposed filter value on the `/maerker` view.

See DDSDK-420.