### PR TITLE
Add a joblistings section.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "drupal/pathauto": "^1.3.0",
         "drupal/redirect": "^1.3.0",
         "drupal/reloadtina": "^1.0.0-alpha1",
+        "drupal/scheduler": "^1.0",
         "drupal/search_api": "^1.11.0",
         "drupal/search_api_exclude_entity": "^1.0.0-beta2",
         "drupal/search_api_solr": "^2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18dbf0baedeadd0bd1ce600f430b93d8",
+    "content-hash": "b3a771417f21ffe52bf70a4f463464a3",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",
@@ -3257,6 +3257,74 @@
             "homepage": "https://www.drupal.org/project/reloadtina",
             "support": {
                 "source": "http://cgit.drupalcode.org/reloadtina"
+            }
+        },
+        {
+            "name": "drupal/scheduler",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/scheduler",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/scheduler-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "213025b64b417f459b73d260d7287ca1f916d587"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "require-dev": {
+                "drupal/devel_generate": "*",
+                "drupal/rules": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1510690385",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Eric Schaefer (Eric Schaefer)",
+                    "homepage": "https://www.drupal.org/u/eric-schaefer",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jonathan Smith (jonathan1055)",
+                    "homepage": "https://www.drupal.org/u/jonathan1055",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Pieter Frenssen (pfrenssen)",
+                    "homepage": "https://www.drupal.org/u/pfrenssen",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Rick Manelius (rickmanelius)",
+                    "homepage": "https://www.drupal.org/u/rickmanelius",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Automatically publish and unpublish content at specified dates and times.",
+            "homepage": "https://drupal.org/project/scheduler",
+            "support": {
+                "source": "http://cgit.drupalcode.org/scheduler",
+                "issues": "https://www.drupal.org/project/issues/scheduler"
             }
         },
         {

--- a/configuration/drupal/core.extension.yml
+++ b/configuration/drupal/core.extension.yml
@@ -27,6 +27,7 @@ module:
   dds_badge: 0
   dds_content_list: 0
   dds_event: 0
+  dds_jobposting: 0
   dds_layout: 0
   dds_link: 0
   dds_metatag: 0

--- a/configuration/drupal/core.extension.yml
+++ b/configuration/drupal/core.extension.yml
@@ -78,6 +78,7 @@ module:
   reloadtina: 0
   responsive_image: 0
   rest: 0
+  scheduler: 0
   search_api: 0
   search_api_exclude_entity: 0
   search_api_solr: 0

--- a/configuration/drupal/forward.settings.yml
+++ b/configuration/drupal/forward.settings.yml
@@ -79,10 +79,10 @@ forward_entity_media_bundle: false
 forward_media_bundle_media_bundle: false
 forward_node_activity: false
 forward_node_article: true
-forward_node_badge: false
+forward_node_badge: 0
 forward_node_download: false
-forward_node_event: false
-forward_node_section_page: false
+forward_node_event: 0
+forward_node_section_page: 0
 forward_entity_node_type: false
 forward_node_type_node_type: false
 forward_entity_paragraph: false

--- a/configuration/drupal/language.content_settings.node.article.yml
+++ b/configuration/drupal/language.content_settings.node.article.yml
@@ -1,0 +1,11 @@
+uuid: 21942a5f-0474-4d7f-b3f6-251f5d6d9761
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+id: node.article
+target_entity_type_id: node
+target_bundle: article
+default_langcode: site_default
+language_alterable: false

--- a/configuration/drupal/language.content_settings.node.event.yml
+++ b/configuration/drupal/language.content_settings.node.event.yml
@@ -1,0 +1,11 @@
+uuid: 01939b86-fae8-4cb8-ac77-d4fd6f24c266
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.event
+id: node.event
+target_entity_type_id: node
+target_bundle: event
+default_langcode: site_default
+language_alterable: false

--- a/configuration/drupal/language/da/views.view.jobpostings.yml
+++ b/configuration/drupal/language/da/views.view.jobpostings.yml
@@ -1,0 +1,6 @@
+display:
+  default:
+    display_options:
+      empty:
+        area_text_custom:
+          content: 'Der er pt. ingen ledige stillinger.'

--- a/configuration/drupal/monitoring.sensor_config.core_requirements_scheduler.yml
+++ b/configuration/drupal/monitoring.sensor_config.core_requirements_scheduler.yml
@@ -1,0 +1,20 @@
+uuid: a02638a2-738a-4002-915f-919d2e437bae
+langcode: da
+status: true
+dependencies:
+  module:
+    - scheduler
+id: core_requirements_scheduler
+label: 'Module scheduler'
+description: 'Requirements of the scheduler module'
+category: Requirements
+plugin_id: core_requirements
+result_class: null
+value_label: null
+value_type: no_value
+caching_time: 3600
+settings:
+  module: scheduler
+  exclude_keys: {  }
+thresholds:
+  type: none

--- a/configuration/drupal/mungo.settings.yml
+++ b/configuration/drupal/mungo.settings.yml
@@ -9,3 +9,5 @@ favicon:
   use_default: 1
 badge_cover_image_path: 'public://maerkeunivers-cover.jpg'
 badge_cover_image: ''
+jobposting_cover_image_path: 'public://maerkeunivers-cover.jpg'
+jobposting_cover_image: ''

--- a/configuration/drupal/node.type.article.yml
+++ b/configuration/drupal/node.type.article.yml
@@ -4,11 +4,23 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
 _core:
   default_config_hash: AeW1SEDgb1OTQACAWGhzvMknMYAJlcZu0jljfeU3oso
 name: Article

--- a/configuration/drupal/node.type.badge.yml
+++ b/configuration/drupal/node.type.badge.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
 name: Badge
 type: badge
 description: ''

--- a/configuration/drupal/node.type.event.yml
+++ b/configuration/drupal/node.type.event.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
 name: Event
 type: event
 description: 'Basic event, courses and other entities that can be displayed in a calendar.'

--- a/configuration/drupal/node.type.section_page.yml
+++ b/configuration/drupal/node.type.section_page.yml
@@ -4,11 +4,23 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Section page'
 type: section_page
 description: 'A page solely defined by paragraph elements. Usually used as frontpage and section frontpages pages.'

--- a/configuration/drupal/scheduler.settings.yml
+++ b/configuration/drupal/scheduler.settings.yml
@@ -1,0 +1,21 @@
+allow_date_only: false
+date_format: 'Y-m-d H:i:s'
+date_letters: djmnFMyY
+date_only_format: Y-m-d
+default_expand_fieldset: when_required
+default_fields_display_mode: vertical_tab
+default_publish_enable: false
+default_publish_past_date: error
+default_publish_required: false
+default_publish_revision: false
+default_publish_touch: false
+default_time: '00:00:00'
+default_unpublish_enable: false
+default_unpublish_required: false
+default_unpublish_revision: false
+lightweight_cron_access_key: a41b7a0f3f4563b1ed86
+log: true
+time_letters: hHgGisaA
+time_only_format: 'H:i:s'
+_core:
+  default_config_hash: JOzWPTQNpL0mkZGbvh0o7T1wKYyGfC3DHHiwhjw2YhU

--- a/configuration/drupal/views.view.jobpostings.yml
+++ b/configuration/drupal/views.view.jobpostings.yml
@@ -1,0 +1,228 @@
+uuid: a2e5f47f-01d0-496c-8bdc-761e4c6a84da
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.extended_teaser
+    - node.type.article
+    - taxonomy.vocabulary.content_tag
+  content:
+    - 'taxonomy_term:content_tag:da0492ae-87a0-4cac-b4a5-a6fe410cc2e6'
+  module:
+    - node
+    - taxonomy
+    - user
+id: jobpostings
+label: Jobpostings
+module: views
+description: 'Lists articles tagged with "jobopslag" and "frivilligjob" or "betalt job".'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: extended_teaser
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            article: article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          value:
+            - 543
+          vid: content_tag
+          plugin_id: taxonomy_index_tid
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: 'No results text - translated via config translation'
+          empty: true
+          tokenize: false
+          content: 'There are currently no vacancies available.'
+          plugin_id: text_custom
+      relationships: {  }
+      arguments:
+        field_content_tag_target_id:
+          id: field_content_tag_target_id
+          table: node__field_content_tag
+          field: field_content_tag_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: 'Missing term id argument'
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+      display_comment: 'List of articles tagged with "jobopslag" and either "frivilligjob" (tid 684) or "betalt job" (tid 685).'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/configuration/drupal/views.view.scheduler_scheduled_content.yml
+++ b/configuration/drupal/views.view.scheduler_scheduled_content.yml
@@ -1,0 +1,855 @@
+uuid: 0d219677-d4f2-4d4a-a7c7-9d88e9af466c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - scheduler
+    - user
+_core:
+  default_config_hash: 76OtYhIMKqji7okkzD9dtqaYCZyBjJdRFOsqJB1DDls
+id: scheduler_scheduled_content
+label: 'Scheduled content'
+module: node
+description: 'Find and manage scheduled content.'
+tag: default
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_options:
+      access:
+        type: scheduler
+      cache:
+        type: tag
+      query:
+        type: views_query
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: true
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            node_bulk_form: node_bulk_form
+            title: title
+            type: type
+            name: name
+            status: status
+            publish_on: publish_on
+            unpublish_on: unpublish_on
+            operations: operations
+          info:
+            node_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            publish_on:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            unpublish_on:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        node_bulk_form:
+          id: node_bulk_form
+          table: node
+          field: node_bulk_form
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          plugin_id: node_bulk_form
+          entity_type: node
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: node
+          entity_field: title
+          type: string
+          settings:
+            link_to_entity: true
+          plugin_id: field
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Content Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          plugin_id: field
+          type: user_name
+          entity_type: user
+          entity_field: name
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: Published
+            format_custom_false: Unpublished
+          plugin_id: field
+          entity_type: node
+          entity_field: status
+        publish_on:
+          id: publish_on
+          table: node_field_data
+          field: publish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Publish on'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: short
+          custom_date_format: ''
+          timezone: ''
+          entity_type: node
+          entity_field: publish_on
+          plugin_id: date
+        unpublish_on:
+          id: unpublish_on
+          table: node_field_data
+          field: unpublish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Unpublish on'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: short
+          custom_date_format: ''
+          timezone: ''
+          entity_type: node
+          entity_field: unpublish_on
+          plugin_id: date
+        operations:
+          id: operations
+          table: node
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          plugin_id: entity_operations
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Published status'
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: bundle
+          entity_type: node
+          entity_field: type
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+          entity_type: node
+          entity_field: title
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: language
+          entity_type: node
+          entity_field: langcode
+        publish_on:
+          id: publish_on
+          table: node_field_data
+          field: publish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 2
+          exposed: false
+          expose:
+            operator_id: publish_on_op
+            label: 'Publish on'
+            description: ''
+            use_operator: true
+            operator: publish_on_op
+            identifier: publish_on
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: 'Publish on'
+            description: null
+            identifier: publish_on
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          entity_type: node
+          entity_field: publish_on
+          plugin_id: date
+        unpublish_on:
+          id: unpublish_on
+          table: node_field_data
+          field: unpublish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 2
+          exposed: false
+          expose:
+            operator_id: unpublish_on_op
+            label: 'Unpublish on'
+            description: ''
+            use_operator: false
+            operator: unpublish_on_op
+            identifier: unpublish_on
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: unpublish_on
+          plugin_id: date
+      sorts: {  }
+      title: 'Scheduled Content'
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No scheduled content.'
+          plugin_id: text_custom
+      arguments: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          admin_label: author
+          required: true
+          plugin_id: standard
+      show_admin_links: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      display_extenders: {  }
+    display_plugin: default
+    display_title: Master
+    id: default
+    position: 0
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      cacheable: false
+      max-age: 0
+      tags: {  }
+  overview:
+    display_options:
+      path: admin/content/scheduled
+      menu:
+        type: tab
+        title: Scheduled
+        description: ''
+        parent: system.admin_content
+        weight: -10
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: normal
+        title: Content
+        description: 'Find and manage scheduled content'
+        menu_name: admin
+        weight: -10
+      display_extenders: {  }
+      display_description: 'Overview of all scheduled content, as a tab on main ''content admin'' page'
+    display_plugin: page
+    display_title: 'Content Overview'
+    id: overview
+    position: 1
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      cacheable: false
+      max-age: 0
+      tags: {  }
+  user_page:
+    display_options:
+      path: user/%user/scheduled
+      menu:
+        type: tab
+        title: Scheduled
+        description: ''
+        parent: system.admin_content
+        weight: -10
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: normal
+        title: Content
+        description: 'Find and manage scheduled content'
+        menu_name: admin
+        weight: -10
+      display_extenders: {  }
+      display_description: 'Scheduled content tab on user profile, showing just that user''s scheduled content'
+      defaults:
+        filters: true
+        filter_groups: true
+        arguments: false
+        access: true
+        empty: false
+      arguments:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: numeric
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content: 'No scheduled content for user {{ arguments.uid }}'
+          plugin_id: text_custom
+    display_plugin: page
+    display_title: 'User profile tab'
+    id: user_page
+    position: 2
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      cacheable: false
+      max-age: 0
+      tags: {  }

--- a/web/modules/custom/dds_jobposting/dds_jobposting.info.yml
+++ b/web/modules/custom/dds_jobposting/dds_jobposting.info.yml
@@ -1,0 +1,6 @@
+name: DDS Jobposting
+type: module
+description: Displays a job-postings page
+core: 8.x
+package: DDS
+

--- a/web/modules/custom/dds_jobposting/dds_jobposting.module
+++ b/web/modules/custom/dds_jobposting/dds_jobposting.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Module that lists jobs.
+ */
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Implements hook_theme().
+ */
+function dds_jobposting_theme($existing, $type, $theme, $path) {
+
+  return [
+    'dds_jobposting' => [
+      'variables' => [
+        'top_image' => [],
+        'paid_jobs' => [],
+        'volunteer_jobs' => [],
+      ]
+    ],
+  ];
+}

--- a/web/modules/custom/dds_jobposting/dds_jobposting.routing.yml
+++ b/web/modules/custom/dds_jobposting/dds_jobposting.routing.yml
@@ -1,0 +1,9 @@
+dds_jobposting.dds_jobposting:
+  path: '/job'
+  defaults:
+    _controller: '\Drupal\dds_jobposting\Controller\JobPostingController::content'
+    _title: 'Jobs'
+    paidJobsTid: 685
+    volunteerJobsTid: 684
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/dds_jobposting/src/Controller/JobPostingController.php
+++ b/web/modules/custom/dds_jobposting/src/Controller/JobPostingController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\dds_jobposting\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Produce a job-posting page.
+ */
+class JobPostingController extends ControllerBase {
+
+  /**
+   * Returns the content
+   *
+   * @return array
+   *   A simple renderable array.
+   */
+
+  /**
+   * Returns the contents of the page.
+   *
+   * @param int $paidJobsTid
+   *   Taxonomy id of the paid job term.
+   *
+   * @param $volunteerJobsTid
+   *   Taxonomy id of the volunteer job term.
+   *
+   * @return array
+   */
+  public function content($paidJobsTid, $volunteerJobsTid) {
+    return   [
+      'jobposting' => [
+        '#theme' => 'dds_jobposting',
+        '#top_image' => [
+          '#theme' => 'dds_top_image',
+          // Setup strings directly to allow for translation.
+          '#title' => new TranslatableMarkup('Jobpostings'),
+          '#subtitle' => new TranslatableMarkup('Jobs in the Danish Guide and Scout Association'),
+          // Use image specified in the theme settings, see
+          // mungo/theme-settings.php.
+          '#image_uri' => theme_get_setting(
+            'jobposting_cover_image_path',
+            'mungo'
+          ),
+        ],
+        // We embed views that lists the jobs and takes the term-id as argument.
+        '#paid_jobs' => views_embed_view('jobpostings', 'default', $paidJobsTid),
+        '#volunteer_jobs' => views_embed_view('jobpostings', 'default', $volunteerJobsTid),
+      ],
+    ];
+
+  }
+}

--- a/web/modules/custom/dds_jobposting/templates/dds-jobposting.html.twig
+++ b/web/modules/custom/dds_jobposting/templates/dds-jobposting.html.twig
@@ -1,0 +1,22 @@
+{{ top_image }}
+<div class="container view-page">
+    <div class="row row-equal-columns deck-box-head">
+        <div class="col-xs-12">
+            <div class="deck-box-head--heading">
+                <div>{{ 'Paid jobs' | t }}</div>
+            </div>
+        </div>
+    </div>
+    {{ paid_jobs }}
+
+    <div class="row row-equal-columns deck-box-head">
+        <div class="col-xs-12">
+            <div class="deck-box-head--heading">
+                <div>{{ 'Volunteer jobs' | t }}</div>
+            </div>
+        </div>
+    </div>
+    {{ volunteer_jobs }}
+
+</div>
+

--- a/web/modules/custom/dds_update/dds_update.install
+++ b/web/modules/custom/dds_update/dds_update.install
@@ -76,15 +76,6 @@ function _dds_update_8104() {
 }
 
 /**
- * Implements hook_install().
- */
-function dds_update_install() {
-  _dds_update_8101();
-  _dds_update_8103();
-  _dds_update_8104();
-}
-
-/**
  * Translations for FB footer.
  */
 function dds_update_update_8101() {

--- a/web/modules/custom/dds_update/dds_update.install
+++ b/web/modules/custom/dds_update/dds_update.install
@@ -104,3 +104,14 @@ function dds_update_update_8103() {
 function dds_update_update_8104() {
   _dds_update_8104();
 }
+
+/**
+ * Add translations for jobpostings.
+ */
+function dds_update_update_8105() {
+  dds_update_add_translation('Jobpostings', 'da', 'Ledige stillinger');
+  dds_update_add_translation('Paid jobs', 'da', 'Betalte stillinger');
+  dds_update_add_translation('Volunteer jobs', 'da', 'Frivillig stillinger');
+  dds_update_add_translation('There are currently no vacancies available.', 'da', 'Der er pt. ingen ledige stillinger.');
+  dds_update_add_translation('Jobs in the Danish Guide and Scout Association', 'da', 'Ledige stillinger i Det Danske Spejderkorps');
+}

--- a/web/themes/custom/mungo/assets_src/sass/layout/deck.scss
+++ b/web/themes/custom/mungo/assets_src/sass/layout/deck.scss
@@ -8,6 +8,12 @@
     padding: $spacing-medium 0;
   }
   position: relative;
+
+  // If used on a view-page, drop the top-padding of the first header as view-page
+  // already have inner padding.
+  .view-page > &:first-child {
+    padding-top: 0;
+  }
 }
 
 // Title, width reduced to wrap if it gets to wide.

--- a/web/themes/custom/mungo/assets_src/sass/layout/view-page.scss
+++ b/web/themes/custom/mungo/assets_src/sass/layout/view-page.scss
@@ -1,6 +1,6 @@
 // Styling for view-pages
 
-// Add top and bottom spacing to be seperated from the pages head/foot.
+// Add top and bottom spacing to be separated from the pages head/foot.
 .view-page {
   margin-top: $spacing-small;
   margin-bottom: $spacing-small;

--- a/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
@@ -37,6 +37,7 @@
 @import "layout/section-page";
 @import "layout/sidedeck";
 @import "layout/layout";
+@import "layout/view-page";
 
 /**
  * SMACSS Components.

--- a/web/themes/custom/mungo/theme-settings.php
+++ b/web/themes/custom/mungo/theme-settings.php
@@ -18,14 +18,12 @@ function mungo_form_system_theme_settings_alter(&$form, FormStateInterface &$for
     return;
   }
 
-  // Add a default-images section.
+  // Settings for the badge-overview-page.
   $form['badge_page_settings'] = array(
     '#type' => 'details',
     '#title' => t('Badge page settings'),
     '#open' => TRUE,
   );
-
-  // Settings for the badge-overview-page.
   $form['badge_page_settings']['badge_cover_image'] = array(
     '#type' => 'container',
   );
@@ -57,31 +55,73 @@ function mungo_form_system_theme_settings_alter(&$form, FormStateInterface &$for
  *   Current state of the form.
  */
 function mungo_badge_cover_image_validate(array $element, FormState &$form_state) {
-  $validators = array('file_validate_is_image' => array());
+  mungo_handle_uploaded_file(
+    $form_state,
+    'badge_cover_image',
+    'dds_badge',
+    'badge_cover_image_path'
+  );
+}
 
+/**
+ * General handling of images in theme settings.
+ *
+ * @param \Drupal\Core\Form\FormState $form_state
+ *   Current state of the form.
+ * @param string $formFieldName
+ *   Field in the settings form to process
+ * @param string $file_usage_module
+ *   The module that will be registered as user of the file.
+ * @param string $themeSettingName
+ *   Name of the theme setting that holds the current image.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function mungo_handle_uploaded_file(
+  FormState $form_state,
+  string $formFieldName,
+  string $file_usage_module,
+  string $themeSettingName ) {
   // Receive the uploaded file and register a file usage.
   /** @var Drupal\file\Entity\File $file */
-  $uploaded_files = file_save_upload('badge_cover_image', $validators, "public://", NULL, FILE_EXISTS_REPLACE);
+  $uploaded_files = file_save_upload(
+    $formFieldName,
+    ['file_validate_is_image' => []],
+    "public://",
+    NULL,
+    FILE_EXISTS_REPLACE
+  );
+
+
+  // Handle th uploaded file if available.
   if (!empty($uploaded_files[0]) && $uploaded_files[0] instanceof FileInterface) {
     $file = $uploaded_files[0];
     $uri = $file->getFileUri();
 
     /** @var \Drupal\file\FileUsage\FileUsageInterface $file_usage */
     $file_usage = \Drupal::service('file.usage');
-    $file_usage->add($file, 'dds_badge', 'file', $file->id());
+
+    // Register the owner module.
+    $file_usage->add($file, $file_usage_module, 'file', $file->id());
 
     // See if we can find the previous image and delete its file-usage.
-    $old_image_uri = theme_get_setting('badge_cover_image_path', 'mungo');
+    $old_image_uri = theme_get_setting($themeSettingName, 'mungo');
     if (!empty($old_image_uri)) {
       $old_file = \Drupal::entityTypeManager()
         ->getStorage('file')
         ->loadByProperties(['uri' => $old_image_uri]);
       if (!empty($old_file)) {
         $old_file = reset($old_file);
-        $file_usage->delete($old_file, 'dds_badge', 'file', $old_file->id());
+        $file_usage->delete(
+          $old_file,
+          $file_usage_module,
+          'file',
+          $old_file->id()
+        );
       }
     }
     // Finish off by accepting the path to the image.
-    $form_state->setValue('badge_cover_image_path', $uri);
+    $form_state->setValue($themeSettingName, $uri);
   }
 }

--- a/web/themes/custom/mungo/theme-settings.php
+++ b/web/themes/custom/mungo/theme-settings.php
@@ -44,6 +44,34 @@ function mungo_form_system_theme_settings_alter(&$form, FormStateInterface &$for
     ),
     '#element_validate' => array('mungo_badge_cover_image_validate'),
   );
+
+  // Settings for the jobposting-overview-page.
+  $form['jobposting_page_settings'] = array(
+    '#type' => 'details',
+    '#title' => t('Jobposting page settings'),
+    '#open' => TRUE,
+  );
+  $form['jobposting_page_settings']['jobposting_cover_image'] = array(
+    '#type' => 'container',
+  );
+  $form['jobposting_page_settings']['jobposting_cover_image']['jobposting_cover_image_path'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Path to the cover-image (use upload-field below)'),
+    '#default_value' => theme_get_setting('jobposting_cover_image_path', 'mungo'),
+    '#description' => t(
+      'The title and description used to be configurable here as well. Now the title of the view and custom header on the view is used instead.'
+    ),
+  );
+  $form['jobposting_page_settings']['jobposting_cover_image']['jobposting_cover_image'] = array(
+    '#type' => 'file',
+    '#title' => t('Upload image image'),
+    '#maxlength' => 40,
+    '#description' => t(
+      "If you don't have direct file access to the server, use this field to upload your image."
+    ),
+    '#element_validate' => array('mungo_jobposting_cover_image_validate'),
+  );
+
 }
 
 /**
@@ -60,6 +88,23 @@ function mungo_badge_cover_image_validate(array $element, FormState &$form_state
     'badge_cover_image',
     'dds_badge',
     'badge_cover_image_path'
+  );
+}
+
+/**
+ * Finalizes upload of the image to use on the jobpostings page.
+ *
+ * @param array $element
+ *   The form-element to be validated.
+ * @param Drupal\Core\Form\FormState $form_state
+ *   Current state of the form.
+ */
+function mungo_jobposting_cover_image_validate(array $element, FormState &$form_state) {
+  mungo_handle_uploaded_file(
+    $form_state,
+    'jobposting_cover_image',
+    'dds_jobposting',
+    'jobposting_cover_image_path'
   );
 }
 


### PR DESCRIPTION
This PR introduces a module that serves up a job-listings page on /jobs

The page is rendered via a custom controller, and the page itself consits of two views that displays articles tagged with specific job-related tags.

The top-image used on the page is configurable via theme settings, and we default using the badge-topimage as
it is already present.

DDSDK-426