### PR TITLE
Simplify mkcert setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       - './docker/cron/setup-cron.sh:/etc/my_init.d/setup-cron.sh'
       - './:/var/www:rw'
       # Add Development root CA and our certificate store.
-      - '${HOME}/Library/Application Support/mkcert:/mkcert/mac:ro'
-      - '${HOME}/.local/share/mkcert:/mkcert/linux:ro'
+      - '${HOME}/.local/share/mkcert:/mkcert:ro'
       - '${HOME}/.local/share/dev_certificates:/cert:rw'
     environment:
       VIRTUAL_HOST: ddsdk.docker


### PR DESCRIPTION
* Simplify mkcert setup
* Make it non-obstrusive for linux users
* Make it consistent with updated guide on https://github.com/reload/docker-drupal-apache-fpm