### PR TITLE
Hardening and redirect on edit submit

### DIFF
--- a/web/modules/custom/dds_link/dds_link.module
+++ b/web/modules/custom/dds_link/dds_link.module
@@ -51,3 +51,30 @@ function _dds_link_validate($element, FormStateInterface &$form_state, $form) {
     $form_state->setError($element, t('External links must have a link text.'));
   }
 }
+
+/**
+ * Implements hook_form__BASE_FORM_ID_alter() for node_form().
+ */
+function dds_link_form_node_form_alter(&$form, FormStateInterface $form_state) {
+  $entity = $form_state->getFormObject()->getEntity();
+
+  if ('download' !== $entity->bundle()) {
+    return;
+  };
+
+  $form['actions']['submit']['#submit'][] = '_dds_link_node_edit_form_redirect';
+}
+
+/**
+ * Node edit redirects to edit on submit.
+ *
+ * @param array $form
+ *   Form array.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ */
+function _dds_link_node_edit_form_redirect(&$form, FormStateInterface $form_state) {
+  $entity = $form_state->getFormObject()->getEntity();
+
+  $form_state->setRedirectUrl($entity->toUrl('edit-form'));
+}

--- a/web/modules/custom/dds_link/src/EventSubscriber/DownloadRedirectSubscriber.php
+++ b/web/modules/custom/dds_link/src/EventSubscriber/DownloadRedirectSubscriber.php
@@ -8,6 +8,7 @@
 namespace Drupal\dds_link\EventSubscriber;
 
 use Drupal\Core\Url;
+use Drupal\file\FileInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -43,6 +44,14 @@ class DownloadRedirectSubscriber implements EventSubscriberInterface {
 
     // Only redirect a certain content type.
     if ($request->attributes->get('node')->getType() !== 'download') {
+      return;
+    }
+
+    if ($request->attributes->get('node')->get('field_file')->isEmpty()) {
+      return;
+    }
+
+    if (!$request->attributes->get('node')->get('field_file')->first()->entity instanceof FileInterface) {
       return;
     }
 

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -7,16 +7,17 @@
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Site\Settings;
-use Drupal\Core\URL;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
+use Drupal\Core\URL;
 use Drupal\dds_activity\ActivityFetcher;
+use Drupal\file\FileInterface;
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\TermInterface;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -428,6 +429,13 @@ function mungo_preprocess_node(&$variables) {
  * Prepare variables for download node type.
  */
 function _mungo_preprocess_node_download(Node $node, &$variables) {
+  if ($node->get('field_file')->isEmpty()) {
+    return;
+  }
+
+  if (!$node->get('field_file')->first()->entity instanceof FileInterface) {
+    return;
+  }
 
   // File url.
   $file = $node->get('field_file')->first()->entity;


### PR DESCRIPTION
Test by creating and editing a download node.

After submit it should redirect back to the edit form.

Page view of a download node should still redirect to the file (if one exists only, though).