### PR TITLE
Add styling to download link to align with "send mail" link

### DIFF
--- a/web/themes/custom/mungo/assets_src/sass/components/download.scss
+++ b/web/themes/custom/mungo/assets_src/sass/components/download.scss
@@ -54,6 +54,10 @@
     }
   }
 
+  &--download {
+    float: left;
+  }
+
   &--send-mail {
     float: right;
   }

--- a/web/themes/custom/mungo/templates/content/node--download--list-teaser.html.twig
+++ b/web/themes/custom/mungo/templates/content/node--download--list-teaser.html.twig
@@ -96,7 +96,7 @@
     <h2 class="node-teaser--heading node-teaser--heading--download">
       {{ label }}
     </h2>
-    <a class="node-teaser--download--link" target="_blank" href="{{ file_url }}">{{ 'Download'|trans }}</a>
+    <a class="node-teaser--download--link node-teaser--download--download" target="_blank" href="{{ file_url }}">{{ 'Download'|trans }}</a>
     <a class="node-teaser--download--link node-teaser--download--send-mail" href="{{ mail_url }}">{{ 'Send by mail'|trans }}</a>
   </div>
   </div>

--- a/web/themes/custom/mungo/templates/content/node--download--teaser.html.twig
+++ b/web/themes/custom/mungo/templates/content/node--download--teaser.html.twig
@@ -95,7 +95,7 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
             {{ label }}
         </h2>
 
-        <a class="node-teaser--download--link" target="_blank" href="{{ file_url }}">{{ 'Download'|trans }}</a>
+        <a class="node-teaser--download--link node-teaser--download--download" target="_blank" href="{{ file_url }}">{{ 'Download'|trans }}</a>
         <a class="node-teaser--download--link node-teaser--download--send-mail" href="{{ mail_url }}">{{ 'Send by mail'|trans }}</a>
     </div>
 </article>


### PR DESCRIPTION
![ddsdk docker_artikel_korpsledelsen (1)](https://user-images.githubusercontent.com/190005/58156009-67713100-7c75-11e9-8113-b4512c58eca3.png)

versus

![ddsdk docker_artikel_korpsledelsen](https://user-images.githubusercontent.com/190005/58156012-6b9d4e80-7c75-11e9-8a8e-427bbc2fa269.png)

Se det i real life på fx https://pr-323-mn4kqoi-55isd6w54kg6s.eu.platform.sh/artikel/korpsledelsen

See DDSDK-310.