### PR TITLE
Add redis cache as cache backend for Drupal

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -7,6 +7,10 @@ name: 'drupal'
 # The runtime the application uses.
 type: "php:7.2"
 
+runtime:
+  extensions:
+    - redis
+
 # Configuration of the build of this application.
 build:
     flavor: composer
@@ -26,7 +30,7 @@ dependencies:
 relationships:
     database: "mysqldb:mysql"
     solr: "solr:ddssolr"
-    # redis: "redis:redis"
+    redis: "rediscache:redis"
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -108,10 +112,6 @@ crons:
         cmd: |
             cd "$PLATFORM_DOCUMENT_ROOT"
             drush core:cron --uri=$(platform route:get --primary --property=url)
-    # Periodic rebuild until large cache tables has been fixed otherwise.
-    cache-rebuild:
-        spec: "* */6 * * *"
-        cmd: "cd web ; drush cache:rebuild"
     snapshot:
         spec: '15 0 * * *'
         cmd: |

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -7,6 +7,9 @@ mysqldb:
     type: mysql:10.0
     disk: 2176
 
+rediscache:
+    type: redis:5.0
+
 solr:
     type: "solr:6.6"
     disk: 2048

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,9 @@
         "drupal/twig_xdebug": "^1.0.0",
         "drupal/video_embed_field": "^1.5.0",
         "drush/drush": "^9",
-        "woothemes/flexslider": "^2.6.3"
+        "woothemes/flexslider": "^2.6.3",
+        "drupal/redis": "^1.1",
+        "predis/predis": "^1.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cce59506f2f3d7c6a7ff1164ea219687",
+    "content-hash": "e6b3b22f8074df33a8c0c16ab643becf",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",
@@ -4284,6 +4284,65 @@
             }
         },
         {
+            "name": "drupal/redis",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/redis.git",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/redis-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "33337fe1cbd2824797e87533b30e4886b48ecd77"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "suggest": {
+                "predis/predis": "^1.1.1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1541600580",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\redis\\": "src"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "pounard",
+                    "homepage": "https://www.drupal.org/user/240164"
+                }
+            ],
+            "description": "Provide a module placeholder, for using as dependency for module that needs Redis.",
+            "homepage": "https://www.drupal.org/project/redis",
+            "support": {
+                "source": "https://git.drupalcode.org/project/redis"
+            }
+        },
+        {
             "name": "drupal/reloadtina",
             "version": "1.0.0-alpha1",
             "source": {
@@ -6089,6 +6148,56 @@
                 "exception"
             ],
             "time": "2015-02-10T20:07:52+00:00"
+        },
+        {
+            "name": "predis/predis",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/nrk/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "time": "2016-06-16T16:22:20+00:00"
         },
         {
             "name": "psr/container",

--- a/configuration/drupal/core.extension.yml
+++ b/configuration/drupal/core.extension.yml
@@ -76,6 +76,7 @@ module:
   path: 0
   pathauto: 0
   redirect: 0
+  redis: 0
   reloadtina: 0
   responsive_image: 0
   rest: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,11 @@ services:
       # on db-data, it will wait until this has completed, and the mount db-datadir
       - 'db-datadir:/var/lib/mysql'
 
+  redis:
+    image: redis:5.0
+    ports:
+      - '6379'
+
   solr:
     image: solr:6.6
     ports:

--- a/web/sites/default/docker.settings.php
+++ b/web/sites/default/docker.settings.php
@@ -58,6 +58,55 @@ $settings['ddsdk_show_sizebar'] = TRUE;
 // Set up stage file proxy.
 $config['stage_file_proxy.settings']['origin'] = 'https://dds.dk/';
 
+// Configure Redis.
+// The docker setup uses the Predis interface for communicating with the Redis
+// server whereas the Platform.sh environments use the PhpRedis interface (with
+// the redis PHP extension). PhpRedis with the extension performs better (see
+// i.e. https://medium.com/@akalongman/phpredis-vs-predis-comparison-on-real-production-data-a819b48cbadb)
+// but would require use to compile the extension ourselves in the Docker image
+// (it cannot be apt installed). So we settle on using the Predis pure PHP
+// implementation in the Docker environments for development purposes but use
+// the extension on Platform.sh where Platform.sh have been kind enough to
+// provide the compiled extension as part of there service.
+$settings['redis.connection']['interface'] = 'Predis';
+$settings['redis.connection']['host'] = 'redis';
+$settings['redis.connection']['port'] = 6379;
+$settings['cache']['default'] = 'cache.backend.redis';
+// Allow the services to work before the Redis module itself is enabled.
+$settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+// Manually add the classloader path, this is required for the container cache bin definition below
+// and allows to use it without the redis module being enabled.
+$class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
+// Use redis for container cache.
+// The container cache is used to load the container definition itself, and
+// thus any configuration stored in the container itself is not available
+// yet. These lines force the container cache to use Redis rather than the
+// default SQL cache.
+$settings['bootstrap_container_definition'] = [
+  'parameters' => [],
+  'services' => [
+    'redis.factory' => [
+      'class' => 'Drupal\redis\ClientFactory',
+    ],
+    'cache.backend.redis' => [
+      'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+      'arguments' => ['@redis.factory', '@cache_tags_provider.container', '@serialization.phpserialize'],
+    ],
+    'cache.container' => [
+      'class' => '\Drupal\redis\Cache\Predis',
+      'factory' => ['@cache.backend.redis', 'get'],
+      'arguments' => ['container'],
+    ],
+    'cache_tags_provider.container' => [
+      'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
+        'arguments' => ['@redis.factory'],
+    ],
+    'serialization.phpserialize' => [
+      'class' => 'Drupal\Component\Serialization\PhpSerialize',
+    ],
+  ],
+];
+
 // Solr config override.
 $config['search_api.server.solr']['backend_config']['connector_config']['host'] = 'solr';
 $config['search_api.server.solr']['backend_config']['connector_config']['path'] = '/solr';

--- a/web/sites/default/platformsh.common.settings.php
+++ b/web/sites/default/platformsh.common.settings.php
@@ -56,6 +56,64 @@ if (isset($_ENV['PLATFORM_RELATIONSHIPS'])) {
   }
 }
 
+// Redis configuration.
+if (!empty($_ENV['PLATFORM_RELATIONSHIPS'])) {
+  $relationships = json_decode(base64_decode($_ENV['PLATFORM_RELATIONSHIPS']), TRUE);
+  if (!empty($relationships['redis'][0]) && !drupal_installation_attempted() && extension_loaded('redis')) {
+    $redis = $relationships['redis'][0];
+    // Set Redis as the default backend for any cache bin not otherwise
+    // specified.
+    $settings['cache']['default'] = 'cache.backend.redis';
+    $settings['redis.connection']['host'] = $redis['host'];
+    $settings['redis.connection']['port'] = $redis['port'];
+    // Apply changes to the container configuration to better leverage Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+    // Manually add the classloader path, this is required for the container
+    // cache bin definition below and allows to use it without the redis module
+    // being enabled.
+    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src');
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
+    $settings['bootstrap_container_definition'] = [
+      'parameters' => [],
+      'services' => [
+        'redis.factory' => [
+          'class' => 'Drupal\redis\ClientFactory',
+        ],
+        'cache.backend.redis' => [
+          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+          'arguments' => [
+            '@redis.factory',
+            '@cache_tags_provider.container',
+            '@serialization.phpserialize',
+          ],
+        ],
+        'cache.container' => [
+          'class' => '\Drupal\redis\Cache\PhpRedis',
+          'factory' => ['@cache.backend.redis', 'get'],
+          'arguments' => ['container'],
+        ],
+        'cache_tags_provider.container' => [
+          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
+          'arguments' => ['@redis.factory'],
+        ],
+        'serialization.phpserialize' => [
+          'class' => 'Drupal\Component\Serialization\PhpSerialize',
+        ],
+      ],
+    ];
+  }
+}
+
 // Configure private and temporary file paths.
 if (isset($_ENV['PLATFORM_APP_DIR'])) {
   if (!isset($settings['file_private_path'])) {


### PR DESCRIPTION
After deploy Drupal will use Redis as cache backend.

To free up space in the cache tables in the database you'll manually have to run:
```sql
TRUNCATE cache_bootstrap;
TRUNCATE cache_config;
TRUNCATE cache_container;
TRUNCATE cache_data;
TRUNCATE cache_default;
TRUNCATE cache_discovery;
TRUNCATE cache_dynamic_page_cache;
TRUNCATE cache_entity;
TRUNCATE cache_menu;
TRUNCATE cache_page;
TRUNCATE cache_render;
TRUNCATE cache_rest;
TRUNCATE cache_toolbar;
```

This PR also removes the periodic `drush cache:rebuild`.