### PR TITLE
Tweak drush cron

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -105,7 +105,9 @@ hooks:
 crons:
     drupal:
         spec: "*/2 * * * *"
-        cmd: "cd web ; drush core-cron"
+        cmd: |
+            cd web
+            drush core:cron --uri=$(platform route:get --primary --property=url)
     # Periodic rebuild until large cache tables has been fixed otherwise.
     cache-rebuild:
         spec: "* */6 * * *"

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -106,7 +106,7 @@ crons:
     drupal:
         spec: "*/5 * * * *"
         cmd: |
-            cd web
+            cd "$PLATFORM_DOCUMENT_ROOT"
             drush core:cron --uri=$(platform route:get --primary --property=url)
     # Periodic rebuild until large cache tables has been fixed otherwise.
     cache-rebuild:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -104,7 +104,7 @@ hooks:
 # The configuration of scheduled execution.
 crons:
     drupal:
-        spec: "*/2 * * * *"
+        spec: "*/5 * * * *"
         cmd: |
             cd web
             drush core:cron --uri=$(platform route:get --primary --property=url)


### PR DESCRIPTION
* Run drush cron with `--uri` option
   Use Platform CLI to get primary URL.
* Only run cron every 5 minutes
   Platform.sh won't schedule it more frequently than that anyway.
* Don't hardcode document root