### PR TITLE
Extend security monitoring to monitor GitHub Security Alerts

### DIFF
--- a/.github/workflows/github-security-jira.yml
+++ b/.github/workflows/github-security-jira.yml
@@ -1,0 +1,20 @@
+name: GitHub Security Alerts for Jira
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  syncSecurityAlerts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Sync security alerts to Jira issues"
+        uses: reload/github-security-jira@v1.x
+        env:
+          GH_SECURITY_TOKEN: ${{ secrets.GitHubSecurityToken }}
+          JIRA_TOKEN: ${{ secrets.JiraApiToken }}
+          JIRA_HOST: https://reload.atlassian.net
+          JIRA_USER: security+jira@reload.dk
+          JIRA_PROJECT: DDSDK
+          JIRA_ISSUE_TYPE: Security
+          JIRA_WATCHERS: ah@dds.dk


### PR DESCRIPTION
Secrets has been added in GitHub settings.

See DDSDK-451.