### PR TITLE
Adding feature from site-reset script taht creates files dir

### DIFF
--- a/scripts/docker/site-reset.sh
+++ b/scripts/docker/site-reset.sh
@@ -6,10 +6,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+FILES=("web/sites/default/files" "private")
 
 # Chmod to 777 if the file is not owned by www-data
 cd "${SCRIPT_DIR}/../../"
-find web/sites/default/files \! -uid 33  \! -print0 -name .gitkeep | sudo xargs -0 chmod 777
+mkdir -p "${FILES[@]}"
+find "${FILES[@]}" \! -uid 33  \! -print0 -name .gitkeep | sudo xargs -0 chmod 777
 
 # Make sites/default read-only and executable
 sudo chmod 555 web/sites/default


### PR DESCRIPTION
#### What does this PR do?
Fixes missing part of site-reset script that creates a sites/default/files dir initially.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
Not directly related. But used for time tracking:
https://reload.atlassian.net/browse/DDSDK-464

#### Screenshots (if appropriate)


#### Questions for the reviewer:
