### PR TITLE
Fix issues with index.php in URLs. DDSDK-479

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9dc1396ab81c5ad99835028c35fa44e",
+    "content-hash": "fd272bf44dbf619722b670858c3f4fd1",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",
@@ -7399,20 +7399,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-31T05:53:42+00:00"
         },
         {

--- a/configuration/drupal/redirect.settings.yml
+++ b/configuration/drupal/redirect.settings.yml
@@ -6,4 +6,4 @@ ignore_admin_path: false
 access_check: false
 _core:
   default_config_hash: IxLwI-D9NeuZKfY2iz87l0NeM8LfBn7IVucsc6RG6l4
-route_normalizer_enabled: null
+route_normalizer_enabled: true


### PR DESCRIPTION
There is an issue, where index.php 'randomly' appears in
some urls. An example:
https://dds.dk/index.php/artikel/nye-spejderchefer-vi-skal-skabe-modige-born-og-unge

It's not all pages, and there is not a clear pattern why
it happens sometimes. The 'real' path is valid, but the
issue appears when links on the website actually links
to the index.php versions.

It appears to be an obscure bug in D8 when using
platform.sh and sitemap/pathauto/others(?)

This commit implements a quickfix, described here:
https://www.drupal.org/project/drupal/issues/3050261

'Just a quick note to let folks know that we installed the
Redirect module and enabled Enforce clean and canonical URLs,
and haven't had the problem return since (it's been weeks).'

It appears to work for DDS too.

-------

Someone has made changes to composer.json without exporting composer.lock (`composer update --lock`).
That caused this PR to fail, so I've also commited the proper lock file.
