### PR TITLE
Changing facebook og tags on the activities search page DDSDK-483

### DIFF
--- a/configuration/drupal/views.view.activities.yml
+++ b/configuration/drupal/views.view.activities.yml
@@ -332,11 +332,11 @@ display:
       display_extenders:
         metatag_display_extender:
           metatags:
-            title: Aktiviteter
-            description: 'Forslag til aktiviteter i en spejdergruppe'
+            title: Aktivitetsdatabasen
+            description: 'Find aktiviteter og lege til spejdermøder og ture'
             og_url: '[current-page:url]'
-            og_title: Arrangementer
-            og_description: 'Kommende arrangementer i Det Danske Spejderkorps'
+            og_title: Aktivitetsdatabasen
+            og_description: 'Find aktiviteter og lege til spejdermøder og ture'
       path: aktiviteter
       display_description: ''
       cache:


### PR DESCRIPTION
#### What does this PR do?
Corrects the opengraph tags on the activity search page.

#### Screenshots
![image](https://user-images.githubusercontent.com/998889/99535349-15fc4c00-29a9-11eb-807e-49e82c8b0356.png)
