### PR TITLE
Tweak phpstan setup in GitHub Actions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Install composer dependencies
         run: |
           composer install --no-interaction --no-progress
+          # Add vendor/bin to PATH for subsequent steps, see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          composer config bin-dir --absolute >> "${GITHUB_PATH}"
       - name: PHPStan analyse
         run: |
-          vendor/bin/phpstan analyse --memory-limit=-1
+          phpstan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  customRulesetUsed: true
+  level: 1
   paths:
    - web/modules/custom
    - web/themes/custom

--- a/web/modules/custom/dds_search/src/Plugin/Block/SearchFormBlock.php
+++ b/web/modules/custom/dds_search/src/Plugin/Block/SearchFormBlock.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   category = @Translation("DDS Search")
  * )
  */
-class SearchFormBlock extends BlockBase implements ContainerFactoryPluginInterface {
+final class SearchFormBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * Drupals form_builder service.


### PR DESCRIPTION
#### What does this PR do?
Tweaks phpstan configuration.

Fixes finding from phpstan:
```
 ------ ----------------------------------------------------------------------------------
  Line   modules/custom/dds_search/src/Plugin/Block/SearchFormBlock.php
 ------ ----------------------------------------------------------------------------------
  42     Unsafe usage of new static().
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static
 ------ ----------------------------------------------------------------------------------
```

#### Where should the reviewer start?
n/a

#### How should this be manually tested?
n/a

#### Any background context you want to provide?
n/a

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
n/a

#### Questions for the reviewer:
n/a