### PR TITLE
Increase persistent disk with 3 GiB

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -87,7 +87,7 @@ web:
                     expires: 2w
 
 # The size of the persistent disk of the application (in MiB).
-disk: 16256
+disk: 19329
 
 # The mounts that will be performed when the package is deployed.
 mounts:


### PR DESCRIPTION
#### What does this PR do?

The Platform.sh plan was increased with 5 GiB. This gives us 2 Gib unallocated disk for later if i.e. the database or solr runs short.

I have mailed Nikolas and Camilla so they can adjust the invoices etc.

#### Where should the reviewer start?

n/a

#### How should this be manually tested?

n/a

#### Any background context you want to provide?

n/a

#### What are the relevant tickets?

n/a

#### Screenshots (if appropriate)

n/a

#### Questions for the reviewer:

n/a
