### PR TITLE
Feature/ddsdk 529

### DIFF
--- a/web/themes/custom/mungo/assets_src/sass/drupal/cookieconsent.scss
+++ b/web/themes/custom/mungo/assets_src/sass/drupal/cookieconsent.scss
@@ -1,0 +1,10 @@
+.cookieconsent-optout {
+  &__all, &__video, &-marketing {
+    display: flex;
+    border: 2px dashed #337ab7;
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    font-weight: 700;
+  }
+}

--- a/web/themes/custom/mungo/assets_src/sass/drupal/video_embed_field.scss
+++ b/web/themes/custom/mungo/assets_src/sass/drupal/video_embed_field.scss
@@ -1,0 +1,3 @@
+.video-embed-field-responsive-video {
+  display: flex;
+}

--- a/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
@@ -88,5 +88,7 @@
  */
 @import "drupal/forms";
 @import "drupal/views";
+@import "drupal/video_embed_field";
+@import "drupal/cookieconsent";
 
 @import "shame";

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -131,6 +131,27 @@ function mungo_preprocess_field(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Lookup cookie settings for providers.
+ */
+function mungo_preprocess_video_embed_iframe(&$variables) {
+  $cookie_consent_categories = [
+    'youtube' => 'marketing',
+  ];
+
+  $url = $variables['url'];
+
+  if (preg_match('/youtube/', $url)) {
+    $provider = 'youtube';
+  }
+
+  if (!empty($provider)) {
+    $variables['cookie_consent_category'] = $cookie_consent_categories[$provider];
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function mungo_form_search_block_form_alter(&$form, FormStateInterface $form_state) {

--- a/web/themes/custom/mungo/templates/misc/video-embed-iframe.html.twig
+++ b/web/themes/custom/mungo/templates/misc/video-embed-iframe.html.twig
@@ -6,10 +6,9 @@
 #}
 {% set cookie_consent_category = cookie_consent_category|default("marketing") %}
 
-<iframe{{ attributes }}{% if url is not empty %} data-src="{{ url }}{% if query is not empty %}?{{ query | url_encode }}{% endif %}{% if fragment is not empty %}#{{ fragment }}{% endif %}"{% endif %} data-cookieconsent="{{ cookie_consent_category|default("marketing") }}"></iframe>
+<iframe{{ attributes }}{% if url is not empty %} data-src="{{ url }}{% if query is not empty %}?{{ query | url_encode }}{% endif %}{% if fragment is not empty %}#{{ fragment }}{% endif %}"{% endif %} data-cookieconsent="{{ cookie_consent_category }}"></iframe>
 <div class="cookieconsent-optout__all cookieconsent-optout__video cookieconsent-optout-{{ cookie_consent_category }}">
   <div class="cookieconsent-optout__accept-text">
     <a href="javascript:Cookiebot.renew();">Acceptér venligst {{ cookie_consent_category|trans }}-cookies for at se filmen</a>
-
   </div>
 </div>


### PR DESCRIPTION
#### What does this PR do?
Properly implement cookie consent overlay on youtube iframes. This should be easy to add to, when other providers show up. It could also easily be made into a config form.

The template is an override of video-embed-iframe from the video_embed_field module, and so I have not updated its functionality - which means I am still using the url/query/fragment form - as we talked about in the other PR. #387 

#### Where should the reviewer start?
https://pr-388-yi4etpi-55isd6w54kg6s.eu.platform.sh/artikel/morgenmaden-sikrer-en-god-start-paa-dagen

Youtube embed  is covered and needs marketing cookie accept.

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots (if appropriate)


#### Questions for the reviewer:
