### PR TITLE
GDPR-compliant FB Pixel tracking. BALDER-542

### DIFF
--- a/web/modules/custom/dds_tracking/dds_tracking.module
+++ b/web/modules/custom/dds_tracking/dds_tracking.module
@@ -140,3 +140,23 @@ function dds_tracking_providers($provider = NULL) {
 
   return $providers;
 }
+
+/**
+ * Implements THEME_preprocess_html().
+ *
+ * Including our tracking scripts, in the HTML Head.
+ */
+function dds_tracking_preprocess_html(&$variables) {
+  // Including facebook pixel script.
+  $variables['page']['#attached']['html_head'][] = [
+    [
+      '#tag' => 'script',
+      '#value' => '!function(f,b,e,v,n,t,s) {if(f.fbq)return;n=f.fbq=function(){n.callMethod? n.callMethod.apply(n,arguments):n.queue.push(arguments)}; if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version="2.0"; n.queue=[];t=b.createElement(e);t.async=!0; t.src=v;s=b.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s)}(window, document,"script", "https://connect.facebook.net/en_US/fbevents.js"); fbq("init", "943660239627910"); fbq("track", "PageView");',
+      '#attributes' => [
+        'data-cookieconsent' => 'marketing',
+        'type' => 'text/plain',
+      ],
+    ],
+    'fb-pixel-script',
+  ];
+}


### PR DESCRIPTION
We do exactly the same on Balder:

https://github.com/reload/balder/blob/master/web/modules/custom/balder_tracking/balder_tracking.module#L16

I've obviously updated the embed code to match what DDS have written in DDSDK-542