### PR TITLE
DG-268: Add 'Målgruppe' vocab as a facet

### DIFF
--- a/configuration/drupal/core.entity_view_display.node.article.default.yml
+++ b/configuration/drupal/core.entity_view_display.node.article.default.yml
@@ -96,3 +96,4 @@ hidden:
   field_content_target_group: true
   field_exclude_from_search: true
   langcode: true
+  search_api_excerpt: true

--- a/configuration/drupal/core.entity_view_display.node.article.teaser.yml
+++ b/configuration/drupal/core.entity_view_display.node.article.teaser.yml
@@ -49,9 +49,11 @@ hidden:
   field_content_category: true
   field_content_tag: true
   field_content_target_group: true
+  field_exclude_from_search: true
   field_metatags: true
   field_paragraphs: true
   field_sidedeck: true
   field_subtitle: true
   langcode: true
   links: true
+  search_api_excerpt: true

--- a/configuration/drupal/facets.facet.activity_type.yml
+++ b/configuration/drupal/facets.facet.activity_type.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: activity_type
-name: Type
+name: Aktivitetstype
 url_alias: activity_type
 weight: 0
 min_count: 1
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: false
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/configuration/drupal/facets.facet.area.yml
+++ b/configuration/drupal/facets.facet.area.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: area
-name: Area
+name: Område
 url_alias: area
 weight: 0
 min_count: 1
@@ -22,6 +22,7 @@ widget:
     soft_limit: 0
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: null
@@ -47,3 +48,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/configuration/drupal/facets.facet.badge_target_group.yml
+++ b/configuration/drupal/facets.facet.badge_target_group.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: badge_target_group
-name: 'Target group'
+name: Målgruppe
 url_alias: badge_target_group
 weight: 0
 min_count: 1
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: false
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/configuration/drupal/facets.facet.content_type.yml
+++ b/configuration/drupal/facets.facet.content_type.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: content_type
-name: 'Content type'
+name: Indholdstype
 url_alias: content_type
 weight: 0
 min_count: 1
@@ -22,6 +22,7 @@ widget:
     soft_limit: 0
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0
@@ -54,3 +55,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/configuration/drupal/facets.facet.duration.yml
+++ b/configuration/drupal/facets.facet.duration.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: duration
-name: Duration
+name: Varighed
 url_alias: duration
 weight: 0
 min_count: 1
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: false
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/configuration/drupal/facets.facet.event_type.yml
+++ b/configuration/drupal/facets.facet.event_type.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: event_type
-name: 'Event type'
+name: Arrangementstype
 url_alias: event_type
 weight: 0
 min_count: 1
@@ -22,6 +22,7 @@ widget:
     soft_limit: 0
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: null
@@ -47,3 +48,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/configuration/drupal/facets.facet.target_group.yml
+++ b/configuration/drupal/facets.facet.target_group.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: target_group
-name: 'Target group'
+name: Målgruppe
 url_alias: target_group
 weight: 0
 min_count: 1
@@ -22,6 +22,7 @@ widget:
     soft_limit: 0
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: null
@@ -47,3 +48,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: null

--- a/configuration/drupal/facets.facet.target_group_taxonomy_term_name.yml
+++ b/configuration/drupal/facets.facet.target_group_taxonomy_term_name.yml
@@ -1,5 +1,5 @@
-uuid: cc398faf-e2f8-4a66-90b7-8f441c4b5d2e
-langcode: en
+uuid: 9f0018be-73e4-4423-a38b-d08095ab1e31
+langcode: da
 status: true
 dependencies:
   config:
@@ -7,19 +7,25 @@ dependencies:
     - views.view.search
   module:
     - search_api
-id: content_type
-name: Indholdstype
-url_alias: content_type
-weight: -2
+id: target_group_taxonomy_term_name
+name: Målgruppe
+url_alias: target_group
+weight: 0
 min_count: 1
 show_only_one_result: false
-field_identifier: type
+field_identifier: field_content_target_group
 facet_source_id: 'search_api:views_page__search__content_search'
 widget:
   type: checkbox
   config:
-    show_numbers: false
-    soft_limit: 0
+    show_numbers: true
+    soft_limit: 10
+    soft_limit_settings:
+      show_less_label: 'Vis færre'
+      show_more_label: 'Vis flere'
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
 query_operator: or
 use_hierarchy: false
 keep_hierarchy_parents_active: false
@@ -29,30 +35,29 @@ hard_limit: 0
 exclude: false
 only_visible_when_facet_source_is_visible: true
 processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: ASC
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: -10
+      sort: 40
     settings:
       sort: ASC
-  exclude_specified_items:
-    processor_id: exclude_specified_items
+  translate_entity:
+    processor_id: translate_entity
     weights:
-      build: -10
-    settings:
-      exclude: 'activity, redirect_page'
-      regex: false
-  list_item:
-    processor_id: list_item
-    weights:
-      build: 5
+      build: -7
     settings: {  }
   url_processor_handler:
     processor_id: url_processor_handler
     weights:
-      pre_query: -10
-      build: -10
+      pre_query: 50
+      build: -8
     settings: {  }
 empty_behavior:
   behavior: none
-show_title: null
+show_title: false

--- a/configuration/drupal/facets.facet.topic_taxonomy_term_name.yml
+++ b/configuration/drupal/facets.facet.topic_taxonomy_term_name.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: topic_taxonomy_term_name
-name: Topic
+name: Emne
 url_alias: topic
 weight: 0
 min_count: 1
@@ -21,10 +21,11 @@ widget:
     show_numbers: true
     soft_limit: 10
     soft_limit_settings:
-      show_less_label: 'Show less'
-      show_more_label: 'Show more'
+      show_less_label: 'Vis færre'
+      show_more_label: 'Vis flere'
 query_operator: or
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/configuration/drupal/facets.facet.topic_taxonomy_term_name.yml
+++ b/configuration/drupal/facets.facet.topic_taxonomy_term_name.yml
@@ -10,7 +10,7 @@ dependencies:
 id: topic_taxonomy_term_name
 name: Emne
 url_alias: topic
-weight: 0
+weight: -1
 min_count: 1
 show_only_one_result: false
 field_identifier: field_content_topic

--- a/configuration/drupal/views.view.search.yml
+++ b/configuration/drupal/views.view.search.yml
@@ -422,7 +422,9 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-      tags: {  }
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.nodes'
   content_search:
     display_plugin: page
     id: content_search
@@ -431,6 +433,10 @@ display:
     display_options:
       display_extenders: {  }
       path: soeg
+      cache:
+        type: none
+      defaults:
+        cache: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -438,4 +444,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-      tags: {  }
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.nodes'


### PR DESCRIPTION
#### What does this PR do?
1. `drush cex` before my changes that seems to be missing
1. Add the "Målgruppe" vocabulary as a new facet to the search view. I've placed it under "Emne" but over "Indholdstype" in the search page, which I think makes the most sense. Let me know what you think 🙂 

#### Where should the reviewer start?
Commit by commit and try and use the search and see if it works as expected.

#### What are the relevant tickets?
DG-268

#### Screenshots (if appropriate)
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/68547893/160621124-193bb5f5-78de-4823-b9dd-63c0fe4f20f7.png">
