### PR TITLE
SPJ-150: Show topic in activity teaser

### DIFF
--- a/web/themes/custom/mungo/assets_src/sass/track/_base.scss
+++ b/web/themes/custom/mungo/assets_src/sass/track/_base.scss
@@ -8,6 +8,9 @@
   @include header-with-bg($targetSelector: page-title);
   @include topic-track($targetSelector: node--keyword);
   @include topic-track($targetSelector: "node-teaser--keyword > *");
+  @include topic-track(
+    $targetSelector: "node--type-activity .node-teaser--keyword"
+  );
 
   ::selection {
     background-color: $track-blue;

--- a/web/themes/custom/mungo/templates/content/node--teaser.html.twig
+++ b/web/themes/custom/mungo/templates/content/node--teaser.html.twig
@@ -97,7 +97,7 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
         </div>
     {% endif %}
     <div class="node-teaser--content-container">
-    {% if content.field_content_topic or content.field_content_topic or content.field_badge_type or content.field_event_type %}
+    {% if content.field_content_topic or content.field_badge_type or content.field_event_type %}
       <div class="node-teaser--keyword {% if has_track_target_group %}node-teaser--keyword-multiple{% endif %}">
         {% if node.bundle in ['article', 'section_page', 'activity', 'redirect_page'] %}
           {% if super_titles %}
@@ -106,7 +106,10 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
                 <li>{{ title }}</li>
               {% endfor %}
             </ul>
+            {% elseif node.bundle == 'activity' %}
+              {{ content.field_content_topic.0['#taxonomy_term'].name.getString() }}
           {% endif %}
+
         {% elseif node.bundle == 'event' %}
           {{ content.field_event_type }}
         {% elseif node.bundle == 'badge' %}


### PR DESCRIPTION
#### What does this PR do?
Show topic in activity teaser

In below screenshots, it's the "BANG" teaser that is an activity
In dds context: 
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/68547893/175913803-a2df8514-2246-4462-997f-2c361fa0372e.png">

In track context: 
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/68547893/175913926-38035dc1-0a26-49c6-a39f-e3315cb45c63.png">

SPJ-150