### PR TITLE
misc fixes for track

### DIFF
--- a/web/themes/custom/mungo/assets_src/sass/track/_section-page.scss
+++ b/web/themes/custom/mungo/assets_src/sass/track/_section-page.scss
@@ -6,7 +6,7 @@ $_left-spacing: 15px;
     border: 0;
   }
 
-  .media--view-mode-track-section-page-hero {
+  .section-header-track .field--name-field-main-media {
     img {
       margin: $_push-overlay-away auto auto;
       height: auto;

--- a/web/themes/custom/mungo/assets_src/sass/track/_section-page.scss
+++ b/web/themes/custom/mungo/assets_src/sass/track/_section-page.scss
@@ -102,7 +102,9 @@ $_left-spacing: 15px;
       &--bg {
         @include rotate-to-left;
 
-        fill: $track-blue;
+        * {
+          fill: $track-blue;
+        }
       }
 
       &--text {
@@ -112,6 +114,14 @@ $_left-spacing: 15px;
       &--text *,
       &--heart {
         fill: $track-light-green;
+      }
+    }
+    @each $track, $track-color in $track-colors {
+      .track-star--#{$track} {
+        .track-star--text *,
+        .track-star--heart {
+          fill: $track-color;
+        }
       }
     }
   }
@@ -356,6 +366,14 @@ $_left-spacing: 15px;
         width: 138px;
         height: 138px;
         right: 7%;
+      }
+    }
+  }
+
+  .section-header-track.is-track-frontpage {
+    .track-star {
+      &--bg {
+        fill: $track-blue;
       }
     }
   }

--- a/web/themes/custom/mungo/templates/track/track-section-page--header.html.twig
+++ b/web/themes/custom/mungo/templates/track/track-section-page--header.html.twig
@@ -1,6 +1,6 @@
 {{ attach_library('mungo/object-fit') }}
 <header
-  class="section-header section-header-track {% if content.field_main_media.0|render %}has-hero-image {% else %}track-{{ track_universe }}-bg has-no-hero-image{% endif %}">
+  class="section-header section-header-track {% if content.field_main_media.0|render %}has-hero-image {% else %}track-{{ track_universe }}-bg has-no-hero-image{% endif %} {% if is_track_frontpage %} is-track-frontpage{% endif %}">
   {% if content.field_main_media.0|render %}
     {{ content.field_main_media }}
     <div class="image-overlay section-header-track--text">


### PR DESCRIPTION
### What does this PR do?
- Don't target on the image view_mode
This makes sure that the image is always "pushed" down correctly on a track page.
- Adjust the track-stars and show them with the correct bg color
Also make sure we style the track-frontpage star correctly.