### PR TITLE
Increase disk usage

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -90,7 +90,7 @@ web:
                     expires: 1m
 
 # The size of the persistent disk of the application (in MiB).
-disk: 21000
+disk: 26624
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -5,7 +5,7 @@
 
 mysqldb:
     type: mysql:10.3
-    disk: 2176
+    disk: 2048
 
 rediscache:
     type: redis:5.0


### PR DESCRIPTION
Adjust allocations to be divisible by 1024.

Current usages:
```console
$ platform db:size -e master
Checking database service mysqldb...

+----------------+-----------------+--------+
| Allocated disk | Estimated usage | % used |
+----------------+-----------------+--------+
| 2.1 GiB        | 1022.2 MiB      | ~ 47%  |
+----------------+-----------------+--------+

Warning
This is an estimate of the database's disk usage. It does not represent its real size on disk.

$ platform mount:size -e master
Checking disk usage for all mounts on 55isd6w54kg6s-master-7rqtwti--drupal@ssh.eu.platform.sh...

+-------------------------+----------+----------+----------+-----------+--------+
| Mount(s)                | Size(s)  | Disk     | Used     | Available | % Used |
+-------------------------+----------+----------+----------+-----------+--------+
| private                 | 8 KiB    | 20.1 GiB | 16.9 GiB | 3.2 GiB   | 84.1%  |
| tmp                     | 148 KiB  |          |          |           |        |
| web/sites/default/files | 16.9 GiB |          |          |           |        |
+-------------------------+----------+----------+----------+-----------+--------+

```