### PR TITLE
Dds 562 search

### DIFF
--- a/configuration/drupal/search_api.index.nodes.yml
+++ b/configuration/drupal/search_api.index.nodes.yml
@@ -515,6 +515,7 @@ processor_settings:
     plugin_id: aggregated_field
     settings: {  }
   entity_status: {  }
+  entity_type: {  }
   html_filter:
     weights:
       preprocess_index: -15
@@ -564,7 +565,9 @@ processor_settings:
     fields:
       node:
         - field_exclude_from_search
-  solr_date_range: {  }
+  solr_date_range:
+    weights:
+      preprocess_index: 0
   type_boost:
     weights:
       preprocess_index: 0
@@ -572,13 +575,13 @@ processor_settings:
       'entity:node':
         datasource_boost: !!float 1
         bundle_boosts:
-          activity: !!float 0
-          article: !!float 0
-          badge: !!float 0
-          download: !!float 0
-          event: !!float 0
+          activity: !!float 1
+          article: !!float 1
+          badge: !!float 1
+          download: !!float 1
+          event: !!float 1
           redirect_page: !!float 2
-          section_page: !!float 0
+          section_page: !!float 1
 tracker_settings:
   default:
     indexing_order: fifo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,18 +112,16 @@ services:
   npm:
     image: node:16
     volumes:
-      - 'cache:/npm-cache'
       - '${PWD}:/var/www'
     working_dir: /var/www
-    tty: true
+    user: "${UID:?Please set the UID environment variable to your numeric user id.}"
     environment:
+      # Use /tmp as home as it's world writable.
+      HOME: '/tmp'
       PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-      npm_config_cache: '/npm-cache/node'
     command: sh -c "npm run build && npm run watch"
 
 volumes:
-  # NPM cache that survives docker-reset.sh
-  cache:
   db-datadir:
   projectroot:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,8 @@ services:
     volumes:
       - '${PWD}:/var/www'
     working_dir: /var/www
-    user: "${UID:?Please set the UID environment variable to your numeric user id.}"
+    # Use UID env variable if set or default to uid 1000.
+    user: "${UID:-1000}"
     environment:
       # Use /tmp as home as it's world writable.
       HOME: '/tmp'


### PR DESCRIPTION
#### What does this PR do?

Make the npm container work for me, and fix the search.

The boost for most content types was set to 0, but boosts are multiplied together, so 0 works as a kill-switch that sets boost to 0 no matter the value of other boosts. This PR sets them to 1 (which is also the default) instead.

#### What are the relevant tickets?

DDSDK-562

#### Screenshots (if appropriate)

Before:
![image](https://user-images.githubusercontent.com/229422/195843478-572b9098-a0a7-4711-bef0-0d6d3e151f7a.png)

And after:
![image](https://user-images.githubusercontent.com/229422/195843524-e827b28b-7176-4f7a-bab4-fd5eeaf5f3a5.png)
