### PR TITLE
Added optional button styling to content-link - DDSDK-621

### DIFF
--- a/configuration/drupal/core.entity_form_display.paragraph.content_link.default.yml
+++ b/configuration/drupal/core.entity_form_display.paragraph.content_link.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_link
   module:
     - link
+    - maxlength
 id: paragraph.content_link.default
 targetEntityType: paragraph
 bundle: content_link
@@ -29,8 +30,11 @@ content:
     region: content
     settings:
       size: 60
-      placeholder: 'Short headline - defaults to "See more"'
-    third_party_settings: {  }
+      placeholder: ''
+    third_party_settings:
+      maxlength:
+        maxlength_js: null
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_show_as_button:
     type: boolean_checkbox
     weight: 2

--- a/configuration/drupal/core.entity_form_display.paragraph.content_link.default.yml
+++ b/configuration/drupal/core.entity_form_display.paragraph.content_link.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.content_link.field_content_link
     - field.field.paragraph.content_link.field_content_link_lead
+    - field.field.paragraph.content_link.field_show_as_button
     - field.field.paragraph.content_link.field_show_thumbnail
     - paragraphs.paragraphs_type.content_link
   module:
@@ -24,11 +25,18 @@ content:
     third_party_settings: {  }
   field_content_link_lead:
     type: string_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 60
       placeholder: 'Short headline - defaults to "See more"'
+    third_party_settings: {  }
+  field_show_as_button:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_show_thumbnail:
     type: boolean_checkbox

--- a/configuration/drupal/core.entity_view_display.paragraph.content_link.default.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_link.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.content_link.field_content_link
     - field.field.paragraph.content_link.field_content_link_lead
+    - field.field.paragraph.content_link.field_show_as_button
     - field.field.paragraph.content_link.field_show_thumbnail
     - paragraphs.paragraphs_type.content_link
 id: paragraph.content_link.default
@@ -20,8 +21,19 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_show_as_button:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   created: true
   field_content_link: true
   field_show_thumbnail: true
+  search_api_excerpt: true
   uid: true

--- a/configuration/drupal/core.entity_view_display.paragraph.content_link.search_index.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.content_link.search_index.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.paragraph.search_index
     - field.field.paragraph.content_link.field_content_link
     - field.field.paragraph.content_link.field_content_link_lead
+    - field.field.paragraph.content_link.field_show_as_button
     - field.field.paragraph.content_link.field_show_thumbnail
     - paragraphs.paragraphs_type.content_link
   module:
@@ -37,5 +38,7 @@ content:
     region: content
 hidden:
   created: true
+  field_show_as_button: true
   field_show_thumbnail: true
+  search_api_excerpt: true
   uid: true

--- a/configuration/drupal/field.field.paragraph.content_link.field_content_link_lead.yml
+++ b/configuration/drupal/field.field.paragraph.content_link.field_content_link_lead.yml
@@ -10,7 +10,7 @@ field_name: field_content_link_lead
 entity_type: paragraph
 bundle: content_link
 label: Lead
-description: 'A short headline that will be displayed over the link. Defaults to "See also" if nothing is specified.'
+description: 'A short headline that will be displayed over the link.'
 required: false
 translatable: false
 default_value: {  }

--- a/configuration/drupal/field.field.paragraph.content_link.field_show_as_button.yml
+++ b/configuration/drupal/field.field.paragraph.content_link.field_show_as_button.yml
@@ -1,0 +1,23 @@
+uuid: 8f71a6e9-038c-466e-a8db-509986b3ab39
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_show_as_button
+    - paragraphs.paragraphs_type.content_link
+id: paragraph.content_link.field_show_as_button
+field_name: field_show_as_button
+entity_type: paragraph
+bundle: content_link
+label: 'Show as button'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Tilsluttet
+  off_label: Afbrudt
+field_type: boolean

--- a/configuration/drupal/field.storage.paragraph.field_show_as_button.yml
+++ b/configuration/drupal/field.storage.paragraph.field_show_as_button.yml
@@ -1,0 +1,18 @@
+uuid: 7a7bb739-26d1-4b73-8f95-470782ec3c83
+langcode: da
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_show_as_button
+field_name: field_show_as_button
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/mungo/assets_src/sass/components/content-link.scss
+++ b/web/themes/custom/mungo/assets_src/sass/components/content-link.scss
@@ -37,6 +37,11 @@
   }
 }
 
+// To make sure the text--title has big font if it stands alone since the text-lead is optional.
+.content-link--text > div:first-of-type {
+  text-transform: uppercase;
+}
+
 // Handle the situation where the content-link container is an a-tag.
 a.content-link {
   // Should act as a block-element to be clickable and have a border.
@@ -48,21 +53,46 @@ a.content-link {
   }
 }
 
+// Styling only active if the show_as_button flag is set.
 .content-link--button {
-  .content-link--text {
-    border-radius: 15px;
+  .content-link--button-wrapper {
+    border-radius: 35px;
     background: $bluish;
     width: 100%;
-    padding: $spacing-medium;
+    padding: 15px 20px;
     text-align: center;
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+    transition: 200ms ease-in-out;
+
+    svg {
+      height: 17px;
+    }
 
     @include media-small {
       width: fit-content;
+
+      svg {
+        height: 24px;
+      }
+    }
+
+    &:hover {
+      background: $marine-lighter-blue;
     }
   }
 
+  .content-link--text--lead {
+    margin-bottom: 0;
+  }
+
+  // To override the default text color so the text is visible on the button background.
   .content-link--text--lead,
-  .content-link--text--title {
+  .content-link--text--title,
+  .content-link--text > div:first-of-type {
     color: white;
   }
 }

--- a/web/themes/custom/mungo/assets_src/sass/components/content-link.scss
+++ b/web/themes/custom/mungo/assets_src/sass/components/content-link.scss
@@ -47,3 +47,22 @@ a.content-link {
     text-decoration: none;
   }
 }
+
+.content-link--button {
+  .content-link--text {
+    border-radius: 15px;
+    background: $bluish;
+    width: 100%;
+    padding: $spacing-medium;
+    text-align: center;
+
+    @include media-small {
+      width: fit-content;
+    }
+  }
+
+  .content-link--text--lead,
+  .content-link--text--title {
+    color: white;
+  }
+}

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -899,10 +899,6 @@ function _mungo_preprocess_paragraph_content_link(&$variables) {
   // Blank out any existing content.
   $variables['content'] = [];
 
-  if ($show_as_button) {
-    $variables['attributes']['class'][] = 'content-link--button';
-  }
-
   // Add our RAs.
   $variables['content']['lead'] = $lead;
   $variables['content']['thumbnail'] = $thumbnail;
@@ -910,6 +906,7 @@ function _mungo_preprocess_paragraph_content_link(&$variables) {
   $variables['content']['alternative_url'] = $alternative_url;
   $variables['content']['target'] = $target;
   $variables['content']['title'] = $title;
+  $variables['content']['show_as_button'] = $show_as_button;
 }
 
 /**

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -819,6 +819,7 @@ function _mungo_preprocess_paragraph_content_link(&$variables) {
   $link = $paragraph->get('field_content_link')->first();
   $lead = empty($paragraph->get('field_content_link_lead')->first()) ? NULL : $paragraph->get('field_content_link_lead')->first()->value;
   $show_thumbnail = (boolean) $variables['paragraph']->get('field_show_thumbnail')->first()->value;
+  $show_as_button = $paragraph->hasField('field_show_as_button') ? $paragraph->get('field_show_as_button')->getString() : NULL;
 
   // Setup the variables we'll try to prepare for the template.
   $thumbnail = NULL;
@@ -897,6 +898,10 @@ function _mungo_preprocess_paragraph_content_link(&$variables) {
 
   // Blank out any existing content.
   $variables['content'] = [];
+
+  if ($show_as_button) {
+    $variables['attributes']['class'][] = 'content-link--button';
+  }
 
   // Add our RAs.
   $variables['content']['lead'] = $lead;

--- a/web/themes/custom/mungo/templates/paragraphs/paragraph--content-link.html.twig
+++ b/web/themes/custom/mungo/templates/paragraphs/paragraph--content-link.html.twig
@@ -43,13 +43,25 @@ set classes = [
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
   'content-link',
+  content.show_as_button ? 'content-link--button' : '',
 ]
 %}
 <a{% if content.target %} target="{{ content.target }}"{% endif %} href="{{ content.alternative_url ? content.alternative_url : content.url }}" {{ attributes.addClass(classes) }}>
   <div class="content-link--image">
       {{ content.thumbnail }}
-  </div><div class="content-link--text">
-    <div class="content-link--text--lead">{% if content.lead %}{{ content.lead }}{% else %}{% trans %}Read also{% endtrans %}{% endif %}</div>
-    <div class="content-link--text--title">{{ content.title }}</div>
+  </div>
+  <div class="content-link--button-wrapper">
+    {% if content.show_as_button %}
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <path d="M16.2947 8.70532C16.6842 8.31578 16.6842 7.68422 16.2947 7.29468V7.29468C15.9054 6.9054 15.2743 6.90511 14.8847 7.29405L10 12.17L10 0.999999C10 0.447714 9.55228 -3.2555e-07 9 -3.49691e-07V-3.49691e-07C8.44772 -3.73832e-07 8 0.447715 8 1L8 12.17L3.11531 7.29405C2.72568 6.90511 2.0946 6.9054 1.70532 7.29468V7.29468C1.31578 7.68422 1.31578 8.31578 1.70532 8.70531L9 16L16.2947 8.70532Z"/>
+        <rect y="18" width="18" height="2" rx="1"/>
+      </svg>
+    {% endif %}
+    <div class="content-link--text">
+      {% if content.lead %}
+        <div class="content-link--text--lead">{{ content.lead }}</div>
+      {% endif %}
+      <div class="content-link--text--title">{{ content.title }}</div>
+    </div>
   </div>
 </a>


### PR DESCRIPTION
#### What does this PR do?
Added a checkbox to enable button styling on the content-link paragraph.

#### Where should the reviewer start?
Se den nye variation af content-link: https://pr-442-7oikaoy-55isd6w54kg6s.eu.platform.sh/artikel/logoer-0

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDSDK-621

#### Screenshots (if appropriate)


#### Questions for the reviewer:
