### PR TITLE
Reallocate 1 GiB from disk to db

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -91,7 +91,7 @@ web:
                     expires: 1m
 
 # The size of the persistent disk of the application (in MiB).
-disk: 26624
+disk: 25600
 
 # The mounts that will be performed when the package is deployed.
 mounts:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -5,7 +5,7 @@
 
 mysqldb:
     type: mysql:10.3
-    disk: 2048
+    disk: 3072
 
 rediscache:
     type: redis:5.0


### PR DESCRIPTION
Database-disken er faretruende tæt på at være fyldt (den har faktisk været det og sitet kun reddet af cache).

Vi flytter lige en enkelt GiB fra disk til DB så den kan holde sig i live.

Disk har stadig plads til dette, men skal nok også udvides inden længe, men så kan vi nå at vende det med kunden når de er på kontoret igen (grundlovsdag..).