### PR TITLE
Added plausible module for DDSDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,7 @@
         "drupal/monitoring": "^1.10",
         "drupal/paragraphs": "^1.6.0",
         "drupal/pathauto": "^1.8",
+        "drupal/plausible_tracking": "^1.0@beta",
         "drupal/raven": "^3.2",
         "drupal/redirect": "^1.3.0",
         "drupal/redis": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dfa5fe1e41ba94a97ec6f161132bc8a",
+    "content-hash": "b55422a8ded2b89fdc0eddd208309f20",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",
@@ -4121,6 +4121,58 @@
                 "source": "https://cgit.drupalcode.org/pathauto",
                 "issues": "https://www.drupal.org/project/issues/pathauto",
                 "documentation": "https://www.drupal.org/docs/8/modules/pathauto"
+            }
+        },
+        {
+            "name": "drupal/plausible_tracking",
+            "version": "1.0.0-beta5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/plausible_tracking.git",
+                "reference": "1.0.0-beta5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/plausible_tracking-1.0.0-beta5.zip",
+                "reference": "1.0.0-beta5",
+                "shasum": "1f4eb180213a4e3176217312526dfb9d1880cdb5"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-beta5",
+                    "datestamp": "1686749008",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "blyme",
+                    "homepage": "https://www.drupal.org/user/3655019"
+                },
+                {
+                    "name": "ras-ben",
+                    "homepage": "https://www.drupal.org/user/3191699"
+                },
+                {
+                    "name": "RoWaBo",
+                    "homepage": "https://www.drupal.org/user/3739176"
+                }
+            ],
+            "description": "Generalized plausible integration.",
+            "homepage": "https://www.drupal.org/project/plausible_tracking",
+            "support": {
+                "source": "https://git.drupalcode.org/project/plausible_tracking"
             }
         },
         {
@@ -15275,6 +15327,7 @@
         "drupal/cookiebot": 15,
         "drupal/field_redirection": 20,
         "drupal/inline_entity_form": 5,
+        "drupal/plausible_tracking": 10,
         "furf/jquery-ui-touch-punch": 20
     },
     "prefer-stable": true,

--- a/configuration/drupal/core.extension.yml
+++ b/configuration/drupal/core.extension.yml
@@ -85,6 +85,7 @@ module:
   path: 0
   path_alias: 0
   pathauto: 0
+  plausible_tracking: 0
   raven: 0
   redirect: 0
   redis: 0

--- a/configuration/drupal/plausible_tracking.settings.yml
+++ b/configuration/drupal/plausible_tracking.settings.yml
@@ -1,0 +1,12 @@
+_core:
+  default_config_hash: aCXw17R4EUqdqjEq_0wpNt8yVzEHT5YmzHSqhVOpPVs
+domain: ddsdk.docker
+admin_pages_enabled: 0
+blocked_ips:
+  - ''
+track_downloads: 1
+enable_unofficial_api: 0
+track_query_params: 1
+query_params:
+  - search_text
+track_outbound_link_click: 1

--- a/web/sites/default/platformsh.env.master.settings.php
+++ b/web/sites/default/platformsh.env.master.settings.php
@@ -12,4 +12,4 @@ $config['raven.settings']['public_dsn'] = 'https://286d4190d96d4bfd91634ed7ef06d
 $config['ddsdk']['enable_linkedin_script'] = TRUE;
 
 // Production tracking scripts, overriding docker.settings.php.
-$config['ddsdk']['plausible_domain'] = 'dds.dk';
+$config['plausible_tracking.settings']['domain'] = 'dds.dk';

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -33,24 +33,7 @@ function mungo_preprocess_html(&$variables) {
   $variables['feature_flags'] = \Drupal::config('feature_flags')->get();
   $variables['enable_linkedin_script'] = \Drupal::config('ddsdk')->get('enable_linkedin_script');
 
-  // Add plausible script.
-  $plausible_domain = \Drupal::config('ddsdk')->get('plausible_domain');
-  if (empty($plausible_domain)) {
-    return;
-  }
 
-  // Including plausible, GDPR-friendly tracking.
-  $variables['page']['#attached']['html_head'][] = [
-    [
-      '#tag' => 'script',
-      '#attributes' => [
-        'src' => 'https://plausible.io/js/script.js',
-        'defer' => TRUE,
-        'data-domain' => $plausible_domain,
-      ],
-    ],
-    'plausible-script',
-  ];
 }
 
 /**


### PR DESCRIPTION
#### What does this PR do?

For DDS.dk: 

Removes the old plausbile script, and adds a new using the plausible_tracking module. 


This can be tested on plausible ddsdk.docker. 


Only the search part is implemented, the filtering part is not. 



Blivspejder.dk has had their script adjusted manually, just wanted to note that here since it's a part of the ticket. 

#### What are the relevant tickets?

[DDSDK-625](https://reload.atlassian.net/browse/DDSDK-625)




[DDSDK-625]: https://reload.atlassian.net/browse/DDSDK-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ