### PR TITLE
blocked dds IP from plausible on prod and changed local settings

### DIFF
--- a/web/sites/default/docker.settings.php
+++ b/web/sites/default/docker.settings.php
@@ -126,4 +126,4 @@ $config['google_analytics.settings']['account'] = 'UA-7162673-26';
 // $config['feature_flags']['hotjar20171127'] = TRUE;
 
 // Add plausible url to local env.
-$config['ddsdk']['plausible_domain'] = 'ddsdk.docker';
+$config['plausible_tracking.settings']['domain'] = 'ddsdk.docker';

--- a/web/sites/default/platformsh.env.master.settings.php
+++ b/web/sites/default/platformsh.env.master.settings.php
@@ -13,3 +13,10 @@ $config['ddsdk']['enable_linkedin_script'] = TRUE;
 
 // Production tracking scripts, overriding docker.settings.php.
 $config['plausible_tracking.settings']['domain'] = 'dds.dk';
+// Blocked IPs. First one is DDS, second is Reload.
+$config['plausible_tracking.settings']['blocked_ips'] = [
+  // dds
+  '152.115.51.222',
+  // reload
+  '109.202.128.38',
+];


### PR DESCRIPTION
#### What does this PR do?

Blocks dds' own IP from plausible. 

Changes the local plausible path to work with the plausible tracking module


#### What are the relevant tickets?


https://reload.atlassian.net/jira/software/c/projects/DDSDK/boards/478?modal=detail&selectedIssue=DDSDK-625




#### Questions for the reviewer:
