### PR TITLE
Removed facebook comments from DDSDK

### DIFF
--- a/web/sites/default/common.settings.php
+++ b/web/sites/default/common.settings.php
@@ -1,3 +1,2 @@
 <?php
-// Default development facebook app-id.
-$config['ddsdk']['facebook']['appid'] = '801746566594693';
+

--- a/web/sites/default/platformsh.env.master.settings.php
+++ b/web/sites/default/platformsh.env.master.settings.php
@@ -1,6 +1,4 @@
 <?php
-// Production facebook app id.
-$config['ddsdk']['facebook']['appid'] = '117491802579';
 
 // Production Google Analytics.
 $config['google_analytics.settings']['account'] = 'UA-7162673-24';

--- a/web/themes/custom/mungo/assets_src/sass/components/_facebook.scss
+++ b/web/themes/custom/mungo/assets_src/sass/components/_facebook.scss
@@ -1,6 +1,0 @@
-// Styling of facebook-related components.
-
-.facebook-comments {
-  border: 1px solid $warm-grey;
-  margin: $spacing-medium 0;
-}

--- a/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
@@ -36,7 +36,6 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "components/block-local-tasks";
 @import "components/box";
 @import "components/content-link";
-@import "components/facebook";
 @import "components/factbox";
 @import "components/share-icons";
 @import "components/grouping-menu";

--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -719,13 +719,7 @@ function _mungo_preprocess_section_page(Node $node, &$variables) {
  * Prepare variables for article-nodes.
  */
 function _mungo_preprocess_node_article(Node $node, &$variables) {
-  $ddsconfig = \Drupal::config('ddsdk');
 
-  // Show facebook-comments on all articles but simple articles.
-  if ($node->field_article_type->value !== 'simple' && !empty($ddsconfig->get('facebook.appid'))) {
-    $variables['facebook_comments'] = TRUE;
-    $variables['facebook_appid'] = $ddsconfig->get('facebook.appid');
-  }
   // Add author presentation.
   if (!empty($node->field_content_author->entity)) {
     $presentation = _mungo_preprocess_author_presentation($node->field_content_author->entity);

--- a/web/themes/custom/mungo/templates/content/node--activity--full.html.twig
+++ b/web/themes/custom/mungo/templates/content/node--activity--full.html.twig
@@ -63,9 +63,6 @@
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
  *   is an administrator.
- * - facebook_appid: Facebook App id to use for social plugins
- * - facebook_comments: if specified facebook-comments are added after the
- *   and facebook_appid is expected to be present
  *
  * @see template_preprocess_node()
  *
@@ -126,26 +123,6 @@
       {% endif %}
     {% endfor %}
   </div>
-{% endblock %}
-{% block content_below_sidebar %}
-  {% if facebook_comments %}
-    <div class="facebook-comments">
-      <div class="fb-comments" data-width="100%" data-href="{{ url('entity.node.canonical', {'node': node.id}) }}" data-numposts="10"></div>
-    </div>
-  {% endif %}
-{% endblock %}
-
-{% block body_head %}
-  {% if facebook_comments %}
-  <div id="fb-root"></div>
-  <script>(function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s); js.id = id;
-      js.src = "//connect.facebook.net/da_DK/sdk.js#xfbml=1&version=v2.8&appId={{ facebook_appid }}";
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));</script>
-  {% endif %}
 {% endblock %}
 
 {% block sidebar %}

--- a/web/themes/custom/mungo/templates/content/node--article--full.html.twig
+++ b/web/themes/custom/mungo/templates/content/node--article--full.html.twig
@@ -63,9 +63,6 @@
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
  *   is an administrator.
- * - facebook_appid: Facebook App id to use for social plugins
- * - facebook_comments: if specified facebook-comments are added after the
- *   and facebook_appid is expected to be present
  *
  * @see template_preprocess_node()
  *
@@ -131,26 +128,9 @@
     {# field_content_author is left out as it is a part of author_presentation #}
     {{ content | without('field_content_author', 'field_subtitle', 'field_main_media', 'field_sidedeck', 'field_content_topic' ) }}
 {% endblock %}
-{% block content_below_sidebar %}
-  {% if facebook_comments %}
-    <div class="facebook-comments">
-      <div class="fb-comments" data-width="100%" data-href="{{ url('entity.node.canonical', {'node': node.id}) }}" data-numposts="10"></div>
-    </div>
-  {% endif %}
-{% endblock %}
 
-{% block body_head %}
-  {% if facebook_comments %}
-  <div id="fb-root"></div>
-  <script>(function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s); js.id = id;
-      js.src = "//connect.facebook.net/da_DK/sdk.js#xfbml=1&version=v2.8&appId={{ facebook_appid }}";
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));</script>
-  {% endif %}
-{% endblock %}
+
+
 
 {% block sidebar %}
 


### PR DESCRIPTION
#### What does this PR do?

Removes everything concerning facebook comments for DDS.dk


#### Where should the reviewer start?

Old PRs for adding facebook comments:

Not saying this is **not**. all,  was just to get an idea if relevant. 

- https://github.com/search?q=repo%3Areload%2Fddsdk2016+facebook+&type=commits



#### How should this be manually tested?

See prod /artikel/plej-jeres-lederfaellesskab
and local /artikel/plej-jeres-lederfaellesskab

I left lost pixel failing so u can see the changes there too / instead. 


The comment thread should not be appearing /be loaded in (iframe) 

Is there something i have not considered to delete ?
