### PR TITLE
Add sleeknote popup for dds.dk

### DIFF
--- a/web/themes/custom/mungo/mungo.theme
+++ b/web/themes/custom/mungo/mungo.theme
@@ -33,6 +33,25 @@ function mungo_preprocess_html(&$variables) {
   $variables['feature_flags'] = \Drupal::config('feature_flags')->get();
   $variables['enable_linkedin_script'] = \Drupal::config('ddsdk')->get('enable_linkedin_script');
 
+  // Add a sleeknote for DDS.dk.
+  // Login with settings can be found in lastpass.
+  // Information for settings/related can be found in DDSDK-676 and DDSDK-674.
+  $script = [
+    '#tag' => 'script',
+    '#attributes' => ['type' => 'text/javascript', 'id' => 'sleeknoteScript'],
+    '#value' => '
+            (function () {
+                 var sleeknoteScriptTag = document.createElement("script");
+                sleeknoteScriptTag.type = "text/javascript";
+                sleeknoteScriptTag.charset = "utf-8";
+                sleeknoteScriptTag.src = ("//sleeknotecustomerscripts.sleeknote.com/150036.js");
+                var s = document.getElementById("sleeknoteScript");
+                s.parentNode.insertBefore(sleeknoteScriptTag, s);
+            })();
+        ',
+  ];
+
+  $variables['#attached']['html_head'][] = [$script, 'sleeknoteScript'];
 }
 
 /**


### PR DESCRIPTION
The information regarding the settings of the popup can be found in the campaign on sleeknote. Login can be found in LP.

DDSDK-676
DDSDK-674

#### What does this PR do?

This PR adds a sleeknote popup to the dds.dk. Specfifically 3 URL's : 

- https://dds.dk/artikel/kan-jeg-blive-spejder-som-voksen
- https://dds.dk/nyleder
- https://dds.dk/rollen-som-spejderleder


As the described in Jira, the popup is supposed to trigger on referral from google. 
For simplicity, i've made it so it current is activated after 3s and scroll of page. It's complicated to test that locally, so i'll do this afterwards. 

For now just test that it works on the 3 mentioned URLs, and not on other pages. 

The campaign is looking at only dds.dk domain (I can't find a reasonable way to add a testing domain in sleeknote). I came around this by doing:

- `sudo vi /etc/hosts`
- Adding: 
```
::1 localhost
127.0.0.1 dds.dk
```
and then using the ID from the `-web`docker container. 

I.e: `http://dds.dk:32789/nyleder`

This should trigger the popup when visiting the 3 pages/urls.




