### PR TITLE
Add generic link card paragraph - DDSDK-737

### DIFF
--- a/configuration/drupal/core.entity_form_display.paragraph.generic_link_card.default.yml
+++ b/configuration/drupal/core.entity_form_display.paragraph.generic_link_card.default.yml
@@ -1,0 +1,43 @@
+uuid: e1fa82b8-356c-471b-a3bf-2647fcae393c
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.generic_link_card.field_generic_link_card_link
+    - field.field.paragraph.generic_link_card.field_generic_link_card_title
+    - field.field.paragraph.generic_link_card.field_generic_link_desc
+    - paragraphs.paragraphs_type.generic_link_card
+  module:
+    - link
+id: paragraph.generic_link_card.default
+targetEntityType: paragraph
+bundle: generic_link_card
+mode: default
+content:
+  field_generic_link_card_link:
+    type: link_default
+    weight: 2
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_generic_link_card_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_generic_link_desc:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/configuration/drupal/core.entity_view_display.paragraph.generic_link_card.default.yml
+++ b/configuration/drupal/core.entity_view_display.paragraph.generic_link_card.default.yml
@@ -1,0 +1,45 @@
+uuid: 47dfd2d0-c5cf-4920-a43c-615a209187db
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.generic_link_card.field_generic_link_card_link
+    - field.field.paragraph.generic_link_card.field_generic_link_card_title
+    - field.field.paragraph.generic_link_card.field_generic_link_desc
+    - paragraphs.paragraphs_type.generic_link_card
+  module:
+    - link
+id: paragraph.generic_link_card.default
+targetEntityType: paragraph
+bundle: generic_link_card
+mode: default
+content:
+  field_generic_link_card_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_generic_link_card_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_generic_link_desc:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/configuration/drupal/field.field.paragraph.2col_deck.field_2col_deck_col1.yml
+++ b/configuration/drupal/field.field.paragraph.2col_deck.field_2col_deck_col1.yml
@@ -97,11 +97,20 @@ settings:
       dynamic_deck:
         weight: -49
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -48
         enabled: false
       gallery:
         weight: -47
+        enabled: false
+      generic_link_card:
+        weight: 58
         enabled: false
       hero_banner:
         weight: -46
@@ -118,6 +127,9 @@ settings:
       latest_content_list:
         weight: -56
         enabled: true
+      latest_content_tagging:
+        weight: 64
+        enabled: false
       list_deck:
         weight: -55
         enabled: true

--- a/configuration/drupal/field.field.paragraph.2col_deck.field_2col_deck_col2.yml
+++ b/configuration/drupal/field.field.paragraph.2col_deck.field_2col_deck_col2.yml
@@ -97,11 +97,20 @@ settings:
       dynamic_deck:
         weight: -49
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -48
         enabled: false
       gallery:
         weight: -47
+        enabled: false
+      generic_link_card:
+        weight: 58
         enabled: false
       hero_banner:
         weight: -46
@@ -118,6 +127,9 @@ settings:
       latest_content_list:
         weight: -56
         enabled: true
+      latest_content_tagging:
+        weight: 64
+        enabled: false
       list_deck:
         weight: -55
         enabled: true

--- a/configuration/drupal/field.field.paragraph.3col_deck.field_3col_deck_col1.yml
+++ b/configuration/drupal/field.field.paragraph.3col_deck.field_3col_deck_col1.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.shortcuts
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       shortcuts: shortcuts
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -40
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -39

--- a/configuration/drupal/field.field.paragraph.3col_deck.field_3col_deck_col2.yml
+++ b/configuration/drupal/field.field.paragraph.3col_deck.field_3col_deck_col2.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.shortcuts
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       shortcuts: shortcuts
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -40
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -39

--- a/configuration/drupal/field.field.paragraph.3col_deck.field_3col_deck_col3.yml
+++ b/configuration/drupal/field.field.paragraph.3col_deck.field_3col_deck_col3.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.shortcuts
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       shortcuts: shortcuts
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -40
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -39

--- a/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col1.yml
+++ b/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col1.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.situation_links
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       situation_links: situation_links
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -39
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -38

--- a/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col2.yml
+++ b/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col2.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.situation_links
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       situation_links: situation_links
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -39
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -38

--- a/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col3.yml
+++ b/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col3.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.situation_links
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       situation_links: situation_links
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -39
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -38

--- a/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col4.yml
+++ b/configuration/drupal/field.field.paragraph.4col_deck.field_4col_deck_col4.yml
@@ -12,6 +12,7 @@ dependencies:
     - paragraphs.paragraphs_type.content_event_reference
     - paragraphs.paragraphs_type.content_redirect_page_reference
     - paragraphs.paragraphs_type.content_section_reference
+    - paragraphs.paragraphs_type.generic_link_card
     - paragraphs.paragraphs_type.markup
     - paragraphs.paragraphs_type.situation_links
     - paragraphs.paragraphs_type.text
@@ -43,6 +44,7 @@ settings:
       content_section_reference: content_section_reference
       markup: markup
       situation_links: situation_links
+      generic_link_card: generic_link_card
     negate: 0
     target_bundles_drag_drop:
       1col_deck:
@@ -93,12 +95,21 @@ settings:
       dynamic_deck:
         weight: -51
         enabled: false
+      embed:
+        weight: 54
+        enabled: false
+      events:
+        weight: 55
+        enabled: false
       factbox:
         weight: -50
         enabled: false
       gallery:
         weight: -49
         enabled: false
+      generic_link_card:
+        weight: 58
+        enabled: true
       hero_banner:
         weight: -48
         enabled: false
@@ -113,6 +124,9 @@ settings:
         enabled: false
       latest_content_list:
         weight: -39
+        enabled: false
+      latest_content_tagging:
+        weight: 64
         enabled: false
       list_deck:
         weight: -38

--- a/configuration/drupal/field.field.paragraph.generic_link_card.field_generic_link_card_link.yml
+++ b/configuration/drupal/field.field.paragraph.generic_link_card.field_generic_link_card_link.yml
@@ -1,0 +1,23 @@
+uuid: 5cd6cf68-8220-4049-a3fd-e561e83257d1
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_generic_link_card_link
+    - paragraphs.paragraphs_type.generic_link_card
+  module:
+    - link
+id: paragraph.generic_link_card.field_generic_link_card_link
+field_name: field_generic_link_card_link
+entity_type: paragraph
+bundle: generic_link_card
+label: Link
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 17
+field_type: link

--- a/configuration/drupal/field.field.paragraph.generic_link_card.field_generic_link_card_title.yml
+++ b/configuration/drupal/field.field.paragraph.generic_link_card.field_generic_link_card_title.yml
@@ -1,0 +1,19 @@
+uuid: 51cb897d-6ac9-4a42-a630-750c1af96d31
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_generic_link_card_title
+    - paragraphs.paragraphs_type.generic_link_card
+id: paragraph.generic_link_card.field_generic_link_card_title
+field_name: field_generic_link_card_title
+entity_type: paragraph
+bundle: generic_link_card
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/configuration/drupal/field.field.paragraph.generic_link_card.field_generic_link_desc.yml
+++ b/configuration/drupal/field.field.paragraph.generic_link_card.field_generic_link_desc.yml
@@ -1,0 +1,19 @@
+uuid: beef0f7e-60d2-46f7-a012-6233a66be90d
+langcode: da
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_generic_link_desc
+    - paragraphs.paragraphs_type.generic_link_card
+id: paragraph.generic_link_card.field_generic_link_desc
+field_name: field_generic_link_desc
+entity_type: paragraph
+bundle: generic_link_card
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/configuration/drupal/field.storage.paragraph.field_generic_link_card_link.yml
+++ b/configuration/drupal/field.storage.paragraph.field_generic_link_card_link.yml
@@ -1,0 +1,19 @@
+uuid: ca28c86a-5b27-4e29-85ca-09ed7e709a71
+langcode: da
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_generic_link_card_link
+field_name: field_generic_link_card_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/configuration/drupal/field.storage.paragraph.field_generic_link_card_title.yml
+++ b/configuration/drupal/field.storage.paragraph.field_generic_link_card_title.yml
@@ -1,0 +1,21 @@
+uuid: 3a385d09-ebf3-47d0-811f-66442c8da7af
+langcode: da
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_generic_link_card_title
+field_name: field_generic_link_card_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 100
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/configuration/drupal/field.storage.paragraph.field_generic_link_desc.yml
+++ b/configuration/drupal/field.storage.paragraph.field_generic_link_desc.yml
@@ -1,0 +1,19 @@
+uuid: 5ebb3d98-7139-4506-aac5-b68cf9deebda
+langcode: da
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_generic_link_desc
+field_name: field_generic_link_desc
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/configuration/drupal/paragraphs.paragraphs_type.generic_link_card.yml
+++ b/configuration/drupal/paragraphs.paragraphs_type.generic_link_card.yml
@@ -1,0 +1,10 @@
+uuid: 44ab38d3-9a89-4b6d-8ea4-11003b09e3ab
+langcode: da
+status: true
+dependencies: {  }
+id: generic_link_card
+label: 'Link card'
+icon_uuid: null
+icon_default: null
+description: 'Link to any kind of content presented as a card with title and description.'
+behavior_plugins: {  }

--- a/web/modules/custom/dds_track/dds_track.module
+++ b/web/modules/custom/dds_track/dds_track.module
@@ -6,7 +6,9 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\dds_track\TrackInterface;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
@@ -283,4 +285,32 @@ function _dds_track_is_track_universe(NodeInterface $node): bool {
   // We know that the node is in a track context, if the parent term is our
   // "Track" tid.
   return $content_category_parent_tid == TrackInterface::TRACK_TERM_ID;
+}
+
+/**
+ * Implements hook_preprocess_paragraph__generic_link_card().
+ *
+ * Check if link is pointing to a track node.
+ * If it is, set a variable to style it differently.
+ */
+function dds_track_preprocess_paragraph__generic_link_card(&$variables): void {
+  $url = $variables['content']['field_generic_link_card_link'][0]['#url'] ?? NULL;
+
+  if (!$url instanceof Url || !$url->isRouted()) {
+    return;
+  }
+
+  $url_node_id = $url->getRouteParameters()['node'] ?? NULL;
+
+  if (!is_numeric($url_node_id)) {
+    return;
+  }
+
+  $node_entity = Node::load($url_node_id);
+
+  if (!$node_entity instanceof NodeInterface) {
+    return;
+  }
+
+  $variables['has_track_styling'] = _dds_track_is_track_universe($node_entity);
 }

--- a/web/themes/custom/mungo/assets_src/sass/components/_block-form-search.scss
+++ b/web/themes/custom/mungo/assets_src/sass/components/_block-form-search.scss
@@ -1,5 +1,5 @@
 .block-search {
-  $_search-border-radius: 10px;
+  $_search-border-radius: $border-radius--small;
   $_search-spacing: $spacing-small-plus;
   $_search-icon-size: 24px;
 

--- a/web/themes/custom/mungo/assets_src/sass/components/_generic-link-card.scss
+++ b/web/themes/custom/mungo/assets_src/sass/components/_generic-link-card.scss
@@ -1,0 +1,58 @@
+.generic-link-card {
+  --generic-link-card-background-color: #{$purple};
+  --generic-link-card-text-color: #{$white-one};
+
+  background: var(--generic-link-card-background-color);
+  border-radius: $border-radius--medium;
+  display: flex;
+  padding: $spacing-medium;
+  flex-direction: column;
+  gap: 5px;
+
+  &:focus,
+  &:active,
+  &:hover {
+    text-decoration: none;
+    cursor: pointer;
+    --generic-link-card-background-color: #{$marine-lighter-blue};
+  }
+
+  // The editor can enable track styling on track-links.
+  &--track {
+    --generic-link-card-background-color: #{$track-light-green};
+    --generic-link-card-text-color: #{$track-blue};
+
+    &:focus,
+    &:active,
+    &:hover {
+      --generic-link-card-background-color: #{$track-blue};
+      --generic-link-card-text-color: #{$track-light-green};
+    }
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__title {
+    margin: 0;
+    @include generic-link-card-header;
+  }
+
+  // Display an icon if the link is external.
+  &__external-icon {
+    display: block;
+    color: var(--generic-link-card-text-color);
+
+    &--hidden {
+      display: none;
+    }
+  }
+
+  &__desc {
+    margin: 0;
+    @include generic-link-card-desc;
+  }
+}

--- a/web/themes/custom/mungo/assets_src/sass/mixins/_typography.mixins.scss
+++ b/web/themes/custom/mungo/assets_src/sass/mixins/_typography.mixins.scss
@@ -384,3 +384,19 @@
     outline: none;
   }
 }
+
+@mixin generic-link-card-header {
+  color: var(--generic-link-card-text-color);
+  font-family: $feature-font;
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+@mixin generic-link-card-desc {
+  color: var(--generic-link-card-text-color);
+  font-family: $manrope-font;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+}

--- a/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
@@ -5,6 +5,14 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "tools/bootstrap.custom";
 
 /**
+ * Track theme tools.
+ *
+ * It's important to load variables and mixins
+ * before components to ensure access.
+ */
+@import "track/track-tools.bundle";
+
+/**
  * SMACSS Base.
  */
 @import "base/functions";
@@ -78,7 +86,7 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "theme/dymo-text";
 
 /**
- * Track theme.
+ * Track theme components.
  */
 @import "track/track.bundle";
 

--- a/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/mungo.bundle.scss
@@ -78,6 +78,7 @@ $output-bourbon-deprecation-warnings: false !default;
 @import "components/burger-menu";
 @import "components/burger-icon";
 @import "components/block-form-search";
+@import "components/generic-link-card";
 
 /**
  * SMACSS Theme.

--- a/web/themes/custom/mungo/assets_src/sass/tools/_colors.scss
+++ b/web/themes/custom/mungo/assets_src/sass/tools/_colors.scss
@@ -30,6 +30,8 @@ $sand--10: #fbf9f6;
 
 $grey: #7a878b;
 
+$purple: #7554a2;
+
 $link--active: $light-navy;
 
 // Define as css variables so they're easy to

--- a/web/themes/custom/mungo/assets_src/sass/tools/_variables.scss
+++ b/web/themes/custom/mungo/assets_src/sass/tools/_variables.scss
@@ -41,3 +41,7 @@ $icon__arrow-down: "\f078";
 // Burger menu.
 $burger-menu-width: 420px;
 $burger-menu-animation-timing: 0.5s;
+
+// Border radius.
+$border-radius--small: 10px;
+$border-radius--medium: 15px;

--- a/web/themes/custom/mungo/assets_src/sass/track/_track-tools.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/track/_track-tools.bundle.scss
@@ -1,0 +1,7 @@
+$track-images: "../images/track";
+
+// Variables and tools for the track theme.
+@import "variables.typography";
+@import "variables.colors";
+@import "variables.structure";
+@import "mixins";

--- a/web/themes/custom/mungo/assets_src/sass/track/_track.bundle.scss
+++ b/web/themes/custom/mungo/assets_src/sass/track/_track.bundle.scss
@@ -1,12 +1,3 @@
-$track-images: "../images/track";
-
-// Variables and tools for the track theme.
-@import "../tools.bundle";
-@import "variables.typography";
-@import "variables.colors";
-@import "variables.structure";
-@import "mixins";
-
 @import "base";
 @import "header";
 @import "teasers";

--- a/web/themes/custom/mungo/templates/paragraphs/paragraph--generic-link-card.html.twig
+++ b/web/themes/custom/mungo/templates/paragraphs/paragraph--generic-link-card.html.twig
@@ -1,0 +1,37 @@
+{% set classes = [
+  'paragraph',
+  'paragraph--type--' ~ paragraph.bundle|clean_class,
+  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  'generic-link-card',
+  has_track_styling ? 'generic-link-card--track' : '',
+] %}
+{% set link_url = content.field_generic_link_card_link.0['#title'] %}
+{% set link_is_external = content.field_generic_link_card_link.0['#url'].isExternal() %}
+
+{% block paragraph %}
+  <a
+    {{ attributes.addClass(classes) }}
+    {{ attributes.setAttribute('href', link_url)}}
+  >
+    <header class="generic-link-card__header">
+      <h2 class="generic-link-card__title">
+        {{ content.field_generic_link_card_title.0['#context'].value }}
+      </h2>
+      <svg
+        class="generic-link-card__external-icon {{ link_is_external ? '' : 'generic-link-card__external-icon--hidden' }}"
+        width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"
+      >
+        <g id="lucide/external-link">
+          <path id="Vector" d="M12.5 2.5H17.5M17.5 2.5V7.5M17.5 2.5L8.33333 11.6667M15 10.8333V15.8333C15 16.2754 14.8244 16.6993 14.5118 17.0118C14.1993 17.3244 13.7754 17.5 13.3333 17.5H4.16667C3.72464 17.5 3.30072 17.3244 2.98816 17.0118C2.67559 16.6993 2.5 16.2754 2.5 15.8333V6.66667C2.5 6.22464 2.67559 5.80072 2.98816 5.48816C3.30072 5.17559 3.72464 5 4.16667 5H9.16667" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </g>
+      </svg>
+    </header>
+
+    {% if content.field_generic_link_desc.0 %}
+      <p class="generic-link-card__desc">
+        {{ content.field_generic_link_desc.0['#context'].value }}
+      </p>
+    {% endif %}
+  </a>
+{% endblock paragraph %}


### PR DESCRIPTION
A basic paragraph that display link cards. Each card has a title and a description. If the link is external an icon is displayed next to the title. If the link points to a track node then it'll get track styling. This is done in a preprocess using a track module helper function that determines if node is track universe.

Enabled the paragraph for column deck 4 and 3 but not for deck 2 since it's broken at the moment. I've created a ticket on it: DDSDK-761.

**Paragraph in 4 and 3 columns**
<img width="1320" alt="Screenshot 2024-07-17 at 10 23 17" src="https://github.com/user-attachments/assets/3935480b-91ad-46b7-9b46-8bda2fd5eb1d">


------------------------------------------------
**Other changes:**

**Fix undefined css track variables**
I had to change the load order of css to ensure that track tools load before components so we have access to variables and mixins. I still load the main track bundle (css for components) after all mungo bundles to make sure track styling override mungo styling.